### PR TITLE
feat: Add Docker/GHCR distribution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Git
+.git
+.gitignore
+
+# IDE
+.idea
+.vscode
+*.iml
+
+# Build artifacts
+build/
+.dart_tool/
+.packages
+
+# Distribution packages (not needed in Docker)
+vscode-extension/
+intellij-plugin/
+npm/
+homebrew/
+docker/
+
+# Documentation
+*.md
+docs/
+assets/
+
+# Tests
+test/
+test_dummy/
+integration_test/
+
+# Scripts
+scripts/
+
+# Config files
+.claude/
+.flutter_skill_uri
+*.log

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,59 @@
+name: Docker
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (e.g., v0.2.19 or latest)'
+        required: true
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Flutter Skill - AI Agent Bridge for Flutter Apps
+# Multi-stage build for minimal image size
+
+# Stage 1: Build
+FROM dart:stable AS builder
+
+WORKDIR /app
+
+# Copy pubspec files first for better caching
+COPY pubspec.yaml pubspec.lock ./
+RUN dart pub get
+
+# Copy source code
+COPY bin/ bin/
+COPY lib/ lib/
+
+# Compile to native executable
+RUN dart compile exe bin/flutter_skill.dart -o flutter_skill
+
+# Stage 2: Runtime
+FROM debian:bookworm-slim
+
+# Install required runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN useradd -m -s /bin/bash flutter_skill
+
+# Copy compiled binary
+COPY --from=builder /app/flutter_skill /usr/local/bin/flutter_skill
+
+# Set ownership
+RUN chown flutter_skill:flutter_skill /usr/local/bin/flutter_skill
+
+# Switch to non-root user
+USER flutter_skill
+WORKDIR /home/flutter_skill
+
+# Default command runs the MCP server
+ENTRYPOINT ["flutter_skill"]
+CMD ["server"]
+
+# Labels for GitHub Container Registry
+LABEL org.opencontainers.image.source="https://github.com/ai-dashboad/flutter-skill"
+LABEL org.opencontainers.image.description="AI Agent Bridge for Flutter Apps - Connect Claude, Cursor, and other AI agents to running Flutter applications"
+LABEL org.opencontainers.image.licenses="MIT"


### PR DESCRIPTION
## Summary
- Add Dockerfile with multi-stage build for minimal image size
- Add .dockerignore to exclude unnecessary files
- Add docker.yml workflow for automated builds on release
- Support both linux/amd64 and linux/arm64 platforms

## Usage
```bash
# Pull the image
docker pull ghcr.io/ai-dashboad/flutter-skill:latest

# Run the MCP server
docker run --rm ghcr.io/ai-dashboad/flutter-skill:latest server
```

## Test plan
- Verify Dockerfile builds successfully
- Verify workflow triggers on release