### PR TITLE
feat: Add Scoop distribution support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,65 @@ jobs:
           name: winget-manifest
           path: AIDashboard.FlutterSkill.yaml
 
+  # Update Scoop manifest
+  update-scoop:
+    needs: [prepare, build-native-binaries]
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Windows binary
+        uses: actions/download-artifact@v4
+        with:
+          name: flutter-skill-windows-x64.exe
+          path: ./
+
+      - name: Calculate SHA256
+        id: sha256
+        shell: pwsh
+        run: |
+          $hash = (Get-FileHash -Algorithm SHA256 "flutter-skill-windows-x64.exe").Hash.ToLower()
+          echo "sha256=$hash" >> $env:GITHUB_OUTPUT
+
+      - name: Update Scoop manifest
+        shell: pwsh
+        run: |
+          $version = "${{ needs.prepare.outputs.version }}"
+          $sha256 = "${{ steps.sha256.outputs.sha256 }}"
+
+          $manifest = @{
+            version = $version
+            description = "AI Agent Bridge for Flutter Apps - Connect Claude, Cursor, and other AI agents to running Flutter applications"
+            homepage = "https://github.com/ai-dashboad/flutter-skill"
+            license = "MIT"
+            architecture = @{
+              "64bit" = @{
+                url = "https://github.com/ai-dashboad/flutter-skill/releases/download/v$version/flutter-skill-windows-x64.exe"
+                hash = $sha256
+              }
+            }
+            bin = @(@("flutter-skill-windows-x64.exe", "flutter-skill"))
+            checkver = @{
+              github = "https://github.com/ai-dashboad/flutter-skill"
+            }
+            autoupdate = @{
+              architecture = @{
+                "64bit" = @{
+                  url = "https://github.com/ai-dashboad/flutter-skill/releases/download/v`$version/flutter-skill-windows-x64.exe"
+                }
+              }
+            }
+          }
+
+          $manifest | ConvertTo-Json -Depth 10 | Out-File -FilePath "flutter-skill.json" -Encoding utf8
+
+      - name: Upload Scoop manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: scoop-manifest
+          path: flutter-skill.json
+
   # Create GitHub Release
   create-release:
     needs: [prepare, publish-pub-dev, publish-npm, publish-vscode, publish-intellij, update-homebrew, build-native-binaries]

--- a/scoop/flutter-skill.json
+++ b/scoop/flutter-skill.json
@@ -1,0 +1,41 @@
+{
+    "version": "0.2.19",
+    "description": "AI Agent Bridge for Flutter Apps - Connect Claude, Cursor, and other AI agents to running Flutter applications",
+    "homepage": "https://github.com/ai-dashboad/flutter-skill",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ai-dashboad/flutter-skill/releases/download/v0.2.19/flutter-skill-windows-x64.exe",
+            "hash": ""
+        }
+    },
+    "bin": [["flutter-skill-windows-x64.exe", "flutter-skill"]],
+    "checkver": {
+        "github": "https://github.com/ai-dashboad/flutter-skill"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ai-dashboad/flutter-skill/releases/download/v$version/flutter-skill-windows-x64.exe"
+            }
+        }
+    },
+    "notes": [
+        "Flutter Skill is now installed!",
+        "",
+        "MCP Configuration (add to your AI agent config):",
+        "{",
+        "  \"mcpServers\": {",
+        "    \"flutter-skill\": {",
+        "      \"command\": \"flutter-skill\",",
+        "      \"args\": [\"server\"]",
+        "    }",
+        "  }",
+        "}",
+        "",
+        "CLI Usage:",
+        "  flutter-skill launch <flutter-project-path>",
+        "  flutter-skill inspect",
+        "  flutter-skill act tap \"button_key\""
+    ]
+}


### PR DESCRIPTION
## Summary
- Add Scoop manifest template
- Add update-scoop job in release workflow
- Generate manifest with SHA256 on each release

## Usage
After release, the Scoop manifest is generated as an artifact.
Can be added to a Scoop bucket or the official scoop-extras bucket.

```powershell
# Add custom bucket (once bucket is set up)
scoop bucket add flutter-skill https://github.com/ai-dashboad/scoop-flutter-skill

# Install
scoop install flutter-skill
```

## Test plan
- Verify release workflow generates Scoop manifest