### PR TITLE
fix: lock mechanism improvements on windows

### DIFF
--- a/lib/src/bridge/web_bridge_proxy.dart
+++ b/lib/src/bridge/web_bridge_proxy.dart
@@ -156,11 +156,14 @@ class WebBridgeProxy {
 
     // Read the SDK script — try common locations
     String? sdkSource;
+    final home = Platform.environment['HOME'] ??
+        Platform.environment['USERPROFILE'];
     final candidates = [
       // Relative to the flutter-skill package
       'sdks/web/flutter-skill.js',
       // npm global install
-      '${Platform.environment['HOME']}/.pub-cache/hosted/pub.dev/flutter_skill-latest/sdks/web/flutter-skill.js',
+      if (home != null)
+        '$home/.pub-cache/hosted/pub.dev/flutter_skill-latest/sdks/web/flutter-skill.js',
     ];
 
     for (final path in candidates) {

--- a/lib/src/cli/init.dart
+++ b/lib/src/cli/init.dart
@@ -470,7 +470,12 @@ Future<void> _configureMCP() async {
   print('');
   print('🤖 Configuring AI agent MCP...');
 
-  final home = Platform.environment['HOME'] ?? '';
+  final home = Platform.environment['HOME'] ??
+      Platform.environment['USERPROFILE'];
+  if (home == null) {
+    print('   Warning: Could not determine home directory');
+    return;
+  }
 
   // Claude Code
   final claudeSettings = File('$home/.claude/settings.json');

--- a/lib/src/cli/quickstart.dart
+++ b/lib/src/cli/quickstart.dart
@@ -773,14 +773,17 @@ Future<String?> _findFlutter() async {
   if (inPath != null) return 'flutter';
 
   // Check common locations
-  final home = Platform.environment['HOME'] ?? '';
+  final home = Platform.environment['HOME'] ??
+      Platform.environment['USERPROFILE'];
   final candidates = [
-    '$home/development/flutter/bin/flutter',
-    '$home/flutter/bin/flutter',
-    '$home/.flutter/bin/flutter',
+    if (home != null) ...[
+      '$home/development/flutter/bin/flutter',
+      '$home/flutter/bin/flutter',
+      '$home/.flutter/bin/flutter',
+      '$home/snap/flutter/common/flutter/bin/flutter',
+      '$home/fvm/default/bin/flutter',
+    ],
     '/opt/flutter/bin/flutter',
-    '$home/snap/flutter/common/flutter/bin/flutter',
-    '$home/fvm/default/bin/flutter',
   ];
   for (final path in candidates) {
     if (await File(path).exists()) {

--- a/lib/src/cli/server.dart
+++ b/lib/src/cli/server.dart
@@ -1041,7 +1041,8 @@ class FlutterMcpServer {
 
 /// Acquire a lock file to prevent multiple server instances
 Future<File?> _acquireLock() async {
-  final home = Platform.environment['HOME'];
+  final home = Platform.environment['HOME'] ??
+      Platform.environment['USERPROFILE'];
   if (home == null) return null;
 
   final lockFile = File('$home/.flutter_skill.lock');

--- a/lib/src/cli/tool_handlers/discovery_helpers.dart
+++ b/lib/src/cli/tool_handlers/discovery_helpers.dart
@@ -43,11 +43,15 @@ extension _DiscoveryHelpers on FlutterMcpServer {
   }
 
   String _findAdb() {
+    final home = Platform.environment['HOME'] ??
+        Platform.environment['USERPROFILE'];
     final androidHome = Platform.environment['ANDROID_HOME'] ??
         Platform.environment['ANDROID_SDK_ROOT'] ??
-        '${Platform.environment['HOME']}/Library/Android/sdk';
-    final adbPath = '$androidHome/platform-tools/adb';
-    if (File(adbPath).existsSync()) return adbPath;
+        (home != null ? '$home/Library/Android/sdk' : null);
+    if (androidHome != null) {
+      final adbPath = '$androidHome/platform-tools/adb';
+      if (File(adbPath).existsSync()) return adbPath;
+    }
     return 'adb'; // fallback to PATH
   }
 

--- a/test/lock_mechanism_test.dart
+++ b/test/lock_mechanism_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Lock Mechanism Tests', () {
-    final lockFilePath = '${Platform.environment['HOME']}/.flutter_skill.lock';
+    final home = Platform.environment['HOME'] ??
+        Platform.environment['USERPROFILE'];
+    final lockFilePath = '${home ?? "/tmp"}/.flutter_skill.lock';
     final lockFile = File(lockFilePath);
 
     tearDown(() async {


### PR DESCRIPTION
Fixes #26 
  ## Problem
  On Windows, the `HOME` environment variable is not set by default. This causes flutter-skill to crash or fail silently
   when trying to access files in the user's home directory (lock files, config files, SDK paths).

  ## Solution
  Replace all direct uses of `Platform.environment['HOME']` with a fallback to `Platform.environment['USERPROFILE']`
  (Windows equivalent), and handle null cases gracefully.

  ## Changes

  ### Core Fixes
  - **server.dart**: Fix lock file acquisition to use `USERPROFILE` fallback
  - **init.dart**: Fix MCP configuration path resolution for Windows
  - **quickstart.dart**: Fix Flutter SDK discovery paths for Windows
  - **discovery_helpers.dart**: Fix ADB path resolution for Windows
  - **web_bridge_proxy.dart**: Fix SDK script path resolution with null safety

  ### Tests
  - **lock_mechanism_test.dart**: Fix test to work on Windows

  ## Testing
  - [x] Verified on Windows 10 (CMD and PowerShell)
  - [x] Lock file acquisition works correctly
  - [x] MCP configuration path resolved properly
  - [x] Flutter/ADB discovery works on Windows
  - [x] No regression on macOS/Linux

  ## Breaking Changes
  None. All changes are backward compatible - they add fallback behavior without changing existing logic for platforms
  where `HOME` is set
  
  
<img width="2480" height="1333" alt="image" src="https://github.com/user-attachments/assets/7de3b462-db00-4266-923d-1568ac81be5a" />
