### PR TITLE
feat: named server registry and --server flag for CLI commands

### DIFF
--- a/bin/flutter_skill.dart
+++ b/bin/flutter_skill.dart
@@ -19,6 +19,7 @@ import 'package:flutter_skill/src/cli/security.dart';
 import 'package:flutter_skill/src/cli/diff.dart';
 import 'package:flutter_skill/src/cli/quickstart.dart';
 import 'package:flutter_skill/src/cli/client.dart';
+import 'package:flutter_skill/src/cli/ping_cmd.dart';
 
 void main(List<String> args) async {
   if (args.isEmpty) {
@@ -30,6 +31,7 @@ void main(List<String> args) async {
     print('  demo         Launch a built-in demo app — zero setup needed');
     print('  launch       Launch and auto-connect to an app');
     print('  connect      Attach to a running Flutter app and name it');
+    print('  ping         Health check one or more named server instances');
     print('  server       Start MCP server / manage named server instances');
     print('  servers      List all running named server instances');
     print('  inspect      Inspect interactive elements');
@@ -110,6 +112,11 @@ void main(List<String> args) async {
       break;
     case 'connect':
       await runConnect(commandArgs);
+      break;
+    case 'ping':
+      // Quick health check for one or more named servers.
+      // Usage: flutter_skill ping --server=<id>[,<id2>,...]
+      await runPing(commandArgs);
       break;
     case 'servers':
       // Shorthand for `server list`

--- a/bin/flutter_skill.dart
+++ b/bin/flutter_skill.dart
@@ -3,6 +3,8 @@ import 'package:flutter_skill/src/cli/launch.dart';
 import 'package:flutter_skill/src/cli/inspect.dart';
 import 'package:flutter_skill/src/cli/act.dart';
 import 'package:flutter_skill/src/cli/server.dart';
+import 'package:flutter_skill/src/cli/server_cmd.dart';
+import 'package:flutter_skill/src/cli/connect.dart';
 import 'package:flutter_skill/src/cli/report_error.dart';
 import 'package:flutter_skill/src/cli/setup_priority.dart';
 import 'package:flutter_skill/src/cli/doctor.dart';
@@ -27,7 +29,9 @@ void main(List<String> args) async {
     print('  quickstart   Guided demo — see flutter-skill in action in 30s');
     print('  demo         Launch a built-in demo app — zero setup needed');
     print('  launch       Launch and auto-connect to an app');
-    print('  server       Start MCP server (used by IDEs)');
+    print('  connect      Attach to a running Flutter app and name it');
+    print('  server       Start MCP server / manage named server instances');
+    print('  servers      List all running named server instances');
     print('  inspect      Inspect interactive elements');
     print('  act          Perform actions (tap, enter_text, scroll)');
     print('  screenshot   Take a screenshot of the running app');
@@ -104,8 +108,22 @@ void main(List<String> args) async {
     case 'act':
       await runAct(commandArgs);
       break;
+    case 'connect':
+      await runConnect(commandArgs);
+      break;
+    case 'servers':
+      // Shorthand for `server list`
+      await runServerCmd(['list', ...commandArgs]);
+      break;
     case 'server':
-      await runServer(commandArgs);
+      // Route server subcommands (list, stop, status) to server_cmd.
+      // Plain `server` (no subcommand) or `server` with MCP flags → MCP server.
+      if (commandArgs.isNotEmpty &&
+          const {'list', 'stop', 'status'}.contains(commandArgs[0])) {
+        await runServerCmd(commandArgs);
+      } else {
+        await runServer(commandArgs);
+      }
       break;
     case 'setup':
       await runSetupPriority(commandArgs);

--- a/docs/cli-server-commands.md
+++ b/docs/cli-server-commands.md
@@ -1,0 +1,1045 @@
+# Named Server Registry and CLI IPC Layer
+
+## Overview
+
+The named server registry and CLI IPC layer is a modern approach to managing connections to Flutter applications without requiring the MCP (Model Context Protocol) server. This feature enables you to:
+
+- **Give running Flutter apps memorable names** using `flutter_skill connect --id=myapp`
+- **Target multiple apps in parallel** with commands like `flutter_skill tap "Button" --server=app-a,app-b`
+- **Work seamlessly across git worktrees** — each worktree targets its named server independently
+- **Integrate easily into CI/CD pipelines** with JSON output and detached process modes
+- **Escape MCP complexity** — use simple CLI commands instead of JSON-RPC protocol details
+
+### The Core Concept: Named Server Instances
+
+Instead of managing a single anonymous connection or relying on a shared MCP server process, each running `flutter_skill` server gets a memorable name (ID). A named server instance is a lightweight daemon that:
+
+1. Holds a connection to a running Flutter application via its VM Service
+2. Listens on a local TCP port (with a Unix socket fast path on macOS/Linux) for incoming commands
+3. Registers itself in `~/.flutter_skill/servers/` so other CLI invocations can find it
+4. Executes commands (tap, inspect, screenshot, etc.) on the app and returns results
+
+This enables a **distribute-and-query** model where multiple tools, scripts, and environments can interact with the same app instance without blocking each other.
+
+---
+
+## Quick Start
+
+### Single App (Backward Compatible)
+
+If you're developing on one app, the workflow is unchanged:
+
+```bash
+# Terminal A: Run your app with Dart VM Service
+flutter run --vm-service-port=50000
+
+# Terminal B: Attach flutter-skill to it (just once)
+flutter_skill connect --id=myapp --port=50000
+# Output: Skill server "myapp" listening on port <random-port>
+#         Press Ctrl+C to stop.
+
+# Terminal C (or anywhere else): Use flutter-skill
+flutter_skill inspect --server=myapp
+flutter_skill tap "Login" --server=myapp
+flutter_skill screenshot "app.png" --server=myapp
+
+# When done
+Ctrl+C in Terminal B
+```
+
+### Multiple Apps in Parallel
+
+If you're testing multiple apps at once (e.g., two different features):
+
+```bash
+# Terminal A: Run feature-auth app
+flutter run -d "iPhone 16" --vm-service-port=50000
+
+# Terminal B: Connect it
+flutter_skill connect --id=feature-auth --port=50000
+
+# Terminal C: Run feature-payments app
+flutter run -d "Pixel 8" --vm-service-port=50001
+
+# Terminal D: Connect it
+flutter_skill connect --id=feature-payments --port=50001
+
+# Now use both apps from anywhere:
+flutter_skill tap "Login" --server=feature-auth
+flutter_skill tap "Pay Now" --server=feature-payments
+
+# Run the same action on both in parallel:
+flutter_skill tap "Logout" --server=feature-auth,feature-payments
+```
+
+### Git Worktrees
+
+Each git worktree is an isolated environment. This feature lets each worktree target its own named server:
+
+```bash
+# Main worktree: run one app
+git checkout main
+flutter run --vm-service-port=50000 &
+flutter_skill connect --id=main-app --port=50000 &
+
+# Worktree A: run a different app
+git worktree add ../wt-feature-a origin/feature-a
+cd ../wt-feature-a
+flutter run --vm-service-port=50001 &
+flutter_skill connect --id=feature-a-app --port=50001 &
+
+# From worktree A, target its own server
+flutter_skill inspect --server=feature-a-app
+flutter_skill tap "New Button" --server=feature-a-app
+
+# Switch back to main and target main's server
+cd ../flutter-skill-cli
+flutter_skill inspect --server=main-app
+```
+
+### CI/CD Pipeline
+
+In continuous integration, you typically can't use interactive terminals. Use `--detach` to start everything in the background:
+
+```bash
+# .github/workflows/e2e.yml
+
+- name: Launch Flutter app in background
+  run: flutter_skill launch . --id=ci-test --device=chrome --detach
+  # Now flutter run + skill server are both running as background processes
+
+- name: Run smoke tests
+  run: |
+    flutter_skill inspect --server=ci-test
+    flutter_skill tap "Login" --server=ci-test
+    flutter_skill enter_text "email" "test@example.com" --server=ci-test
+    flutter_skill tap "Submit" --server=ci-test
+    flutter_skill screenshot "dashboard.png" --server=ci-test
+  # Output is automatically JSON when CI=true (GitHub Actions sets this)
+
+- name: Cleanup
+  if: always()
+  run: flutter_skill server stop --id=ci-test
+  # Kills both flutter run and skill server
+```
+
+---
+
+## Commands Reference
+
+### `flutter_skill connect`
+
+**Attach flutter-skill to a running Flutter app and register it with a name.**
+
+```bash
+flutter_skill connect --id=<name> [--port=<port>|--uri=<uri>] \
+  [--project=<path>] [--device=<device-id>]
+```
+
+#### Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--id=<name>` | Yes | — | Server name (alphanumeric, hyphens, underscores only). |
+| `--port=<port>` | No | — | VM Service port (e.g., 50000). Either this or `--uri` must be provided. |
+| `--uri=<uri>` | No | — | Full VM Service URI (e.g., `ws://127.0.0.1:50000/ws` or `http://127.0.0.1:50000`). |
+| `--project=<path>` | No | `.` | Project directory (stored in registry for reference). |
+| `--device=<id>` | No | — | Device ID (stored in registry for reference). |
+
+#### Behavior
+
+- Connects to the running Flutter app via VM Service
+- Starts a JSON-RPC server on a random free local TCP port
+- Registers the server in `~/.flutter_skill/servers/<name>.json`
+- **Stays in foreground** — prints logs and waits for `Ctrl+C` to disconnect cleanly
+- On `Ctrl+C`: closes the server, unregisters from the registry, and exits
+
+#### Examples
+
+```bash
+# Connect to app on port 50000, name it "myapp"
+flutter_skill connect --id=myapp --port=50000
+
+# Connect using a full URI (useful for discovery output)
+flutter_skill connect --id=myapp \
+  --uri=ws://127.0.0.1:50000/ws \
+  --project=/Users/you/projects/myapp \
+  --device="iPhone 16 Pro"
+
+# Connect with auto-discovery (looks up URI automatically)
+flutter_skill connect --id=myapp
+```
+
+#### Exit Codes
+
+- `0` — Connected and cleanly shut down
+- `1` — Failed to connect or invalid arguments
+
+---
+
+### `flutter_skill launch`
+
+**Start a Flutter app and optionally register a named server for it.**
+
+```bash
+flutter_skill launch [<project-path>] [--id=<name>] [--detach] [<flutter-args>...]
+```
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `--id=<name>` | Optional. If provided, automatically starts a skill server with this name once the app is running. |
+| `--detach` | Optional. Spawns the skill server in a detached background process. Useful for CI/CD. Without this flag, the skill server runs in the same process. |
+| `<flutter-args>` | Any flags you'd normally pass to `flutter run` (e.g., `-d "iPhone 16"`, `-r` for release mode). |
+
+#### Behavior
+
+- Runs `flutter run` with your project
+- Auto-adds `--vm-service-port=50000` if no other port is specified (recommended for faster discovery)
+- If `--id` is provided:
+  - Once the VM Service is ready, starts a skill server with that ID
+  - Registers it in the server registry
+  - Writes `.flutter_skill_server` file in the project directory (for auto-discovery by other commands)
+- If `--detach` is provided:
+  - Spawns the skill server as a separate background process
+  - Parent `flutter run` continues in foreground (you see app output normally)
+  - Useful when you want to keep the `flutter run` window open for interactive debugging
+- Without `--detach`:
+  - Skill server runs in the same process (non-blocking background task)
+
+#### Examples
+
+```bash
+# Launch app and attach a skill server (in-process)
+flutter_skill launch . --id=myapp
+
+# Launch app, attach skill server, and run flutter in background
+flutter_skill launch . --id=myapp --detach
+
+# Launch on a specific device
+flutter_skill launch . --id=myapp -d "iPhone 16" --detach
+
+# Launch in release mode
+flutter_skill launch . --id=myapp -r --detach
+
+# Custom VM Service port
+flutter_skill launch . --id=myapp --vm-service-port=8888
+```
+
+#### Exit Codes
+
+- `0` — App exited cleanly
+- `1` — Setup failed or app crashed
+
+---
+
+### `flutter_skill server list`
+
+**Show all registered skill servers and their status.**
+
+```bash
+flutter_skill server list [--output=json|human]
+```
+
+#### Output (Human)
+
+```
+Running skill servers:
+
+ID                  PORT     PID      PROJECT
+myapp               52341    84921    /Users/you/projects/myapp
+feature-auth        52342    84922    /Users/you/projects/feature-auth
+feature-payments    52343    84923    /Users/you/projects/feature-payments
+```
+
+#### Output (JSON)
+
+```json
+[
+  {
+    "id": "myapp",
+    "port": 52341,
+    "pid": 84921,
+    "projectPath": "/Users/you/projects/myapp",
+    "deviceId": "iPhone 16 Pro",
+    "vmServiceUri": "ws://127.0.0.1:50000/ws",
+    "startedAt": "2026-04-01T10:30:00.000Z"
+  }
+]
+```
+
+#### Notes
+
+- Automatically filters out stale entries (processes that are no longer running)
+- Shows "unreachable" status next to servers whose TCP port is not responding
+- In CI environments (when `CI=true` or `GITHUB_ACTIONS=true`), JSON output is default
+
+---
+
+### `flutter_skill server stop`
+
+**Stop a named skill server and clean up its registry entry.**
+
+```bash
+flutter_skill server stop --id=<name> [--output=json|human]
+```
+
+#### Behavior
+
+- Sends a shutdown signal to the skill server
+- Server unregisters itself from the registry
+- If the server process is unreachable, manually cleans up the registry entry
+- Exits with code 0 if stopped successfully, 1 if the ID does not exist
+
+#### Examples
+
+```bash
+flutter_skill server stop --id=myapp
+
+# In CI, capture the result as JSON
+flutter_skill server stop --id=ci-test --output=json
+```
+
+#### Output
+
+```
+Server "myapp" stopped.
+```
+
+---
+
+### `flutter_skill server status`
+
+**Show detailed status of a named skill server.**
+
+```bash
+flutter_skill server status --id=<name> [--output=json|human]
+```
+
+#### Output (Human)
+
+```
+Server: myapp
+  Status  : running
+  Port    : 52341
+  PID     : 84921
+  Project : /Users/you/projects/myapp
+  Device  : iPhone 16 Pro
+  URI     : ws://127.0.0.1:50000/ws
+  Started : 2026-04-01 10:30:00.000
+```
+
+#### Output (JSON)
+
+```json
+{
+  "id": "myapp",
+  "port": 52341,
+  "pid": 84921,
+  "projectPath": "/Users/you/projects/myapp",
+  "deviceId": "iPhone 16 Pro",
+  "vmServiceUri": "ws://127.0.0.1:50000/ws",
+  "startedAt": "2026-04-01T10:30:00.000Z",
+  "alive": true
+}
+```
+
+---
+
+### `flutter_skill servers`
+
+**Shorthand for `flutter_skill server list`.**
+
+```bash
+flutter_skill servers [--output=json|human]
+```
+
+Identical to `flutter_skill server list`. Useful for quick checks.
+
+---
+
+### `flutter_skill inspect`
+
+**Inspect the interactive elements of a Flutter app.**
+
+```bash
+flutter_skill inspect [--server=<id>[,<id2>,...]] [--output=json|human]
+```
+
+#### Without `--server` (Auto-Discovery)
+
+- Uses `.flutter_skill_server` file if present (written by `launch`)
+- Falls back to `.flutter_skill_uri` file if present (backward compatibility)
+- If multiple servers are running, prompts you to specify one
+- Otherwise, uses direct VM Service connection via discovery
+
+#### With `--server`
+
+- Connects to the named server(s) via the registry
+
+#### Examples
+
+```bash
+# Auto-discover (works after flutter_skill launch . --id=myapp)
+flutter_skill inspect
+
+# Target a specific server
+flutter_skill inspect --server=myapp
+
+# Target multiple servers (concurrent)
+flutter_skill inspect --server=feature-auth,feature-payments
+
+# JSON output for parsing
+flutter_skill inspect --server=myapp --output=json
+```
+
+#### Output (Human)
+
+```
+Interactive Elements:
+- **ElevatedButton** [Key: "loginBtn"] [Text: "Login"]
+  - **Text** [Text: "Login"]
+- **TextField** [Key: "emailField"]
+- **Row** [Key: "header"]
+  - **Text** [Text: "Welcome"]
+```
+
+#### Output (JSON)
+
+```json
+{
+  "elements": [
+    {
+      "type": "ElevatedButton",
+      "key": "loginBtn",
+      "text": "Login"
+    },
+    {
+      "type": "TextField",
+      "key": "emailField"
+    }
+  ]
+}
+```
+
+---
+
+### `flutter_skill act` (and related commands)
+
+**Perform actions on a Flutter app (tap, enter text, scroll, screenshot, etc.).**
+
+```bash
+flutter_skill act <action> [<params>...] [--server=<id>[,<id2>,...]]
+flutter_skill tap <key-or-text> [--server=<id>[,<id2>,...]]
+flutter_skill enter_text <key> <text> [--server=<id>[,<id2>,...]]
+flutter_skill swipe [<direction>] [<distance>] [--server=<id>[,<id2>,...]]
+flutter_skill scroll_to <key-or-text> [--server=<id>[,<id2>,...]]
+flutter_skill screenshot [<output-path>] [--server=<id>[,<id2>,...]]
+```
+
+#### Available Actions
+
+| Action | Parameters | Description |
+|--------|-----------|-------------|
+| `tap` | `<key-or-text>` | Tap a button or widget by key or visible text. |
+| `enter_text` | `<key> <text>` | Enter text into a text field. |
+| `swipe` | `[<direction>] [<distance>]` | Swipe the screen (up, down, left, right). Default: 300px up. |
+| `scroll_to` | `<key-or-text>` | Scroll until a widget is visible. |
+| `screenshot` | `[<path>]` | Capture the screen. Saves to file or prints base64 if no path given. |
+| `get_text` | `<key>` | Get the text value of a widget. |
+| `wait_for_element` | `<key-or-text> [<timeout-ms>]` | Wait for a widget to appear (default timeout 5000ms). |
+| `assert_visible` | `<key-or-text>` | Verify a widget is visible; fail if not. |
+| `assert_gone` | `<key-or-text>` | Verify a widget is NOT visible; fail if it is. |
+| `go_back` | — | Trigger Android back button or iOS back gesture. |
+| `hot_reload` | — | Hot reload the app. |
+| `hot_restart` | — | Hot restart the app. |
+
+#### Examples
+
+```bash
+# Single app (auto-discovery)
+flutter_skill tap "Login"
+
+# Specific server
+flutter_skill tap "Login" --server=myapp
+
+# Multiple servers (runs in parallel)
+flutter_skill tap "Login" --server=app-a,app-b
+
+# Enter text
+flutter_skill enter_text "email" "user@example.com" --server=myapp
+
+# Scroll and assert
+flutter_skill scroll_to "Submit Button" --server=myapp
+flutter_skill assert_visible "Submit Button" --server=myapp
+
+# Capture screenshot
+flutter_skill screenshot "screenshots/login.png" --server=myapp
+
+# Wait for element to appear (up to 10 seconds)
+flutter_skill wait_for_element "Dashboard" 10000 --server=myapp
+
+# Hot reload
+flutter_skill hot_reload --server=myapp
+
+# Get text value
+flutter_skill get_text "emailLabel" --server=myapp
+```
+
+#### Output (Human, Single Server)
+
+```
+Tapped "Login"
+```
+
+or
+
+```
+Entered text "user@example.com" into "email"
+```
+
+#### Output (Human, Multiple Servers)
+
+```
+[app-a] tap completed (123ms)
+[app-b] tap completed (145ms)
+```
+
+#### Output (JSON)
+
+```json
+[
+  {
+    "server": "app-a",
+    "action": "tap",
+    "success": true,
+    "duration_ms": 123
+  },
+  {
+    "server": "app-b",
+    "action": "tap",
+    "success": true,
+    "duration_ms": 145
+  }
+]
+```
+
+---
+
+## Use Cases
+
+### Single Developer Workflow
+
+You're developing a single app and want simple commands without MCP complexity.
+
+```bash
+# Start your app (one terminal)
+flutter run --vm-service-port=50000
+
+# In another terminal, attach flutter-skill
+flutter_skill connect --id=myapp --port=50000
+
+# From anywhere, use flutter-skill
+flutter_skill inspect --server=myapp
+flutter_skill tap "Login"
+flutter_skill enter_text "email" "test@example.com"
+flutter_skill tap "Submit"
+flutter_skill screenshot "result.png"
+```
+
+**Benefit**: No MCP server to manage. Just two CLI commands and you're done.
+
+---
+
+### Multiple Apps in Parallel
+
+You're testing two features simultaneously on different devices or emulators.
+
+```bash
+# Terminal 1: Feature A on iPhone
+flutter run -d "iPhone 16 Pro" --vm-service-port=50000
+# Terminal 2
+flutter_skill connect --id=feature-a --port=50000
+
+# Terminal 3: Feature B on Pixel 8
+flutter run -d "Pixel 8" --vm-service-port=50001
+# Terminal 4
+flutter_skill connect --id=feature-b --port=50001
+
+# Now, from anywhere, test both:
+flutter_skill tap "Login" --server=feature-a
+flutter_skill tap "Login" --server=feature-b
+
+# Or run the same action on both in parallel:
+flutter_skill tap "Logout" --server=feature-a,feature-b
+```
+
+**Benefit**: No context switching. Both apps are always available via named servers. Script or automate across multiple apps seamlessly.
+
+---
+
+### Git Worktrees Without MCP
+
+Each git worktree is an isolated environment. Normally, if two worktrees want to use flutter-skill, they'd have to share a single MCP server (which doesn't work well) or duplicate the MCP setup.
+
+With named servers, each worktree independently targets its own server:
+
+```bash
+# Main branch worktree
+git checkout main
+cd /path/to/flutter-skill-cli
+flutter run --vm-service-port=50000 &
+flutter_skill connect --id=main --port=50000 &
+
+# Feature A worktree
+git worktree add ../wt-a origin/feature-a
+cd ../wt-a
+flutter run --vm-service-port=50001 &
+flutter_skill connect --id=feature-a --port=50001 &
+
+# Feature B worktree
+git worktree add ../wt-b origin/feature-b
+cd ../wt-b
+flutter run --vm-service-port=50002 &
+flutter_skill connect --id=feature-b --port=50002 &
+
+# Now each worktree can independently test:
+# In wt-a:
+flutter_skill tap "New Button" --server=feature-a
+
+# In wt-b:
+flutter_skill tap "Updated Flow" --server=feature-b
+
+# Back in main:
+flutter_skill tap "Original Button" --server=main
+```
+
+**Benefit**: Zero coordination between worktrees. Each one runs its own flutter app and skill server independently. Perfect for parallel feature development.
+
+---
+
+### CI/CD Pipeline
+
+In a CI pipeline, there's no interactive terminal. Use `--detach` to start everything in the background and `--output=json` for machine-readable results.
+
+```yaml
+# .github/workflows/e2e.yml
+name: E2E Tests
+
+on: [push, pull_request]
+
+jobs:
+  e2e:
+    runs-on: macos-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: subosito/flutter-action@v2
+      
+      - name: Install flutter-skill CLI
+        run: dart pub global activate --source path .
+      
+      - name: Launch app in background
+        run: |
+          flutter_skill launch . \
+            --id=ci-test \
+            --device=chrome \
+            --detach
+      
+      - name: Wait for app readiness
+        run: |
+          for i in {1..30}; do
+            if flutter_skill ping --server=ci-test 2>/dev/null; then
+              echo "App is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "App failed to start"
+          exit 1
+      
+      - name: Run smoke tests
+        run: |
+          # All these run with JSON output (CI=true from GitHub Actions)
+          flutter_skill tap "Login" --server=ci-test
+          flutter_skill enter_text "email" "test@ci.com" --server=ci-test
+          flutter_skill enter_text "password" "secret123" --server=ci-test
+          flutter_skill tap "Sign In" --server=ci-test
+          flutter_skill assert_visible "Dashboard" --server=ci-test
+          flutter_skill screenshot "dashboard.png" --server=ci-test
+      
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: screenshots
+          path: "*.png"
+      
+      - name: Cleanup
+        if: always()
+        run: flutter_skill server stop --id=ci-test
+```
+
+**Benefits**:
+- No interactive prompts; everything runs unattended
+- `--detach` starts the app and server as background processes
+- `CI=true` (set automatically by GitHub Actions) triggers JSON output
+- Easily parse results for pass/fail decisions
+- Clean shutdown with `server stop` ensures resources are freed
+
+---
+
+### Testing Against Remote VM Service
+
+If your Flutter app is running on a remote machine, you can still use flutter-skill by connecting to the remote VM Service URI.
+
+```bash
+# On the app's machine (or wherever flutter run is)
+flutter run --vm-service-port=50000
+
+# On your local machine, connect to the remote
+flutter_skill connect --id=remote-app \
+  --uri=ws://192.168.1.100:50000/ws \
+  --project="/path/to/project" \
+  --device="remote-emulator"
+
+# Now use flutter-skill locally
+flutter_skill inspect --server=remote-app
+flutter_skill tap "Login" --server=remote-app
+```
+
+**Benefit**: Great for testing shared CI machines or testing with apps running on team infrastructure without needing to duplicate the development environment locally.
+
+---
+
+## Server Registry
+
+### Location
+
+All server registration data is stored in `~/.flutter_skill/servers/` (cross-platform):
+
+```
+~/.flutter_skill/
+  servers/
+    myapp.json          ← Server registration file (human-readable JSON)
+    myapp.sock          ← Unix socket (optional, macOS/Linux only, for lower latency)
+    feature-auth.json
+    feature-auth.sock
+```
+
+### Server Entry Format
+
+Each `.json` file contains:
+
+```json
+{
+  "id": "myapp",
+  "port": 52341,
+  "pid": 84921,
+  "projectPath": "/Users/you/projects/myapp",
+  "deviceId": "iPhone 16 Pro",
+  "vmServiceUri": "ws://127.0.0.1:50000/ws",
+  "startedAt": "2026-04-01T10:30:00.000Z"
+}
+```
+
+| Field | Purpose |
+|-------|---------|
+| `id` | The server name (must match the filename without `.json`) |
+| `port` | Local TCP port the server listens on |
+| `pid` | Process ID of the server (used to detect stale entries) |
+| `projectPath` | Project directory (for reference and organizing server lists) |
+| `deviceId` | Device identifier (for reference, e.g., "iPhone 16 Pro") |
+| `vmServiceUri` | Full VM Service URI of the connected Flutter app |
+| `startedAt` | ISO 8601 timestamp when the server started |
+
+### Cleanup
+
+- **Stale entries are automatically cleaned up** when you list servers. If a registered server's PID is no longer running, it's silently removed.
+- **Manual cleanup**: Delete `~/.flutter_skill/servers/<id>.json` and `~/.flutter_skill/servers/<id>.sock` (if present) to unregister a server.
+- **Broken connections**: If a server crashes, its registry entry is cleaned up the next time you run `flutter_skill server list`.
+
+---
+
+## Output Formats
+
+### Human-Readable Output (Default)
+
+Optimized for developers reading output in a terminal:
+
+```bash
+$ flutter_skill tap "Login"
+Tapped "Login"
+
+$ flutter_skill inspect
+Interactive Elements:
+- **ElevatedButton** [Key: "loginBtn"] [Text: "Login"]
+  - **Text** [Text: "Login"]
+- **TextField** [Key: "emailField"]
+
+$ flutter_skill server list
+Running skill servers:
+
+ID                  PORT     PID      PROJECT
+myapp               52341    84921    /Users/you/projects/myapp
+feature-auth        52342    84922    /Users/you/projects/feature-auth
+```
+
+### JSON Output
+
+Machine-readable format for CI, scripting, and automation:
+
+```bash
+$ flutter_skill tap "Login" --output=json
+{"server":"myapp","action":"tap","success":true,"duration_ms":123}
+
+$ flutter_skill server list --output=json
+[{"id":"myapp","port":52341,"pid":84921,...}]
+```
+
+### Automatic CI Detection
+
+When running in a CI environment, output is automatically JSON:
+
+- GitHub Actions: `GITHUB_ACTIONS=true`
+- CircleCI: `CIRCLECI=true`
+- Travis CI: `TRAVIS=true`
+- Buildkite: `BUILDKITE=true`
+- Generic CI: `CI=true`
+
+Override with `--output=human` if needed:
+
+```bash
+# CI environment defaults to JSON
+flutter_skill tap "Login" --server=myapp
+# Output: {"server":"myapp",...}
+
+# Force human output even in CI
+flutter_skill tap "Login" --server=myapp --output=human
+# Output: Tapped "Login"
+```
+
+---
+
+## Architecture
+
+### Communication Model
+
+The named server registry uses a **distributed client-server model** over local IPC:
+
+```
+┌─ Developer Machine ────────────────────────────────┐
+│                                                    │
+│  flutter_skill launch      ← starts flutter run   │
+│  flutter_skill connect     ← attaches skill server│
+│                                                    │
+│  ┌──────────────────────────────────────────────┐ │
+│  │         SkillServer Instance (myapp)         │ │
+│  │  - Listens on TCP 127.0.0.1:52341            │ │
+│  │  - (Optional Unix socket: ~/.flutter_skill/  │ │
+│  │    servers/myapp.sock)                       │ │
+│  │  - Registered in ~/.flutter_skill/servers/   │ │
+│  │    myapp.json                                │ │
+│  └──────────────────────────────────────────────┘ │
+│           ▲                                        │
+│           │ JSON-RPC 2.0                          │
+│           │ (TCP or Unix socket)                  │
+│           │                                        │
+│  ┌────────┴────────────────────────────────────┐ │
+│  │     CLI Client (flutter_skill tap ...)      │ │
+│  │  1. Read ~/.flutter_skill/servers/myapp.json│ │
+│  │  2. Connect to 127.0.0.1:52341              │ │
+│  │  3. Send JSON-RPC request                   │ │
+│  │  4. Receive response, print to user         │ │
+│  └──────────────────────────────────────────────┘ │
+│                                                    │
+└────────────────────────────────────────────────────┘
+```
+
+### SkillServer: The Daemon
+
+`SkillServer` is the long-lived process that runs during `flutter_skill connect` or `flutter_skill launch`. It:
+
+1. **Owns the AppDriver connection**: Maintains a WebSocket connection to the Flutter app's VM Service
+2. **Runs a JSON-RPC server**: Listens on a local TCP port and optionally a Unix socket
+3. **Dispatches commands**: Receives requests (tap, screenshot, etc.), delegates to AppDriver, and returns results
+4. **Self-manages lifecycle**: Unregisters from the registry when shut down
+
+### SkillClient: The CLI Tool
+
+`SkillClient` is what the CLI uses to communicate with a `SkillServer`. It:
+
+1. **Resolves the server**: Reads `~/.flutter_skill/servers/<id>.json` to find the port
+2. **Connects**: Establishes a TCP socket (or prefers Unix socket on macOS/Linux)
+3. **Sends one request**: A single JSON-RPC call with the command and parameters
+4. **Reads the response**: Waits for the result and returns it
+5. **Closes the socket**: Cleans up immediately
+
+### ServerRegistry: The Catalog
+
+`ServerRegistry` manages the `~/.flutter_skill/servers/` directory:
+
+- **Register**: Write `<id>.json` with server metadata when a server starts
+- **List**: Read all `.json` files, filter out stale PIDs, return active servers
+- **Get**: Retrieve a single server's metadata by ID
+- **Unregister**: Delete `<id>.json` and `<id>.sock` when a server stops
+- **Check alive**: Try to connect to the server's TCP port to verify it's responsive
+
+### JSON-RPC 2.0 Protocol
+
+Commands are sent as newline-delimited JSON-RPC 2.0 requests:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tap",
+  "params": {
+    "text": "Login"
+  }
+}
+```
+
+Success response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "success": true
+  }
+}
+```
+
+Error response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32000,
+    "message": "Element not found: 'Login'"
+  }
+}
+```
+
+---
+
+## Troubleshooting
+
+### "No server registered with id 'myapp'"
+
+**Problem**: You tried to use `--server=myapp` but that server hasn't been started yet.
+
+**Solution**:
+1. Verify the server is running: `flutter_skill server list`
+2. If not listed, start it: `flutter_skill connect --id=myapp --port=50000`
+3. The registry is in `~/.flutter_skill/servers/` — check for `myapp.json`
+
+### "Could not connect to server: Connection refused"
+
+**Problem**: The server is registered but not responding on its TCP port.
+
+**Solution**:
+1. Check if the server process is still running: `flutter_skill server status --id=myapp`
+2. If the PID is no longer alive, unregister it: `flutter_skill server stop --id=myapp`
+3. Check if the Flutter app itself crashed
+4. Restart the server: `flutter_skill connect --id=myapp --port=50000`
+
+### Server appears in list but shows "unreachable"
+
+**Problem**: A server entry is in the registry but the TCP port is not responding.
+
+**Solution**:
+- This often means the server process crashed but didn't clean up its registry file
+- Clean it up: `flutter_skill server stop --id=myapp`
+- Or manually delete: `rm ~/.flutter_skill/servers/myapp.json`
+- Restart: `flutter_skill connect --id=myapp --port=50000`
+
+### "Found DTD URI but no VM Service URI"
+
+**Problem**: Flutter couldn't establish the VM Service (despite DTD being available). This is rare with modern Flutter versions.
+
+**Solution**:
+1. Ensure you're on Flutter 3.x or later: `flutter --version`
+2. Try explicitly setting a VM Service port: `--vm-service-port=8888`
+3. Try a different port if 50000 is already in use
+4. Check that the device/emulator is responding normally (try `flutter doctor`)
+
+### Multiple servers running but `flutter_skill inspect` asks me to specify one
+
+**Problem**: You used `flutter_skill inspect` without `--server=<id>` and there are multiple servers running.
+
+**Solution**:
+- Explicitly name the server: `flutter_skill inspect --server=myapp`
+- Or set the default: `export FLUTTER_SKILL_SERVER=myapp` then `flutter_skill inspect`
+- Or use the `.flutter_skill_server` file by running from the project directory
+
+### Command hangs or times out
+
+**Problem**: A `flutter_skill` command is waiting too long or hanging indefinitely.
+
+**Solution**:
+1. Press `Ctrl+C` to interrupt
+2. Check if the Flutter app is responsive (look at the app window)
+3. Check if the skill server process is running: `flutter_skill server list`
+4. Try a simpler command first (e.g., `flutter_skill server list`) to verify connectivity
+5. Check system resource usage (disk, memory, CPU) — the app might be thrashing
+
+### Unix socket not being used (always TCP on macOS/Linux)
+
+**Problem**: You expected lower latency via Unix socket but the CLI is using TCP.
+
+**Solution**:
+- This is fine; TCP is the default and reliable
+- Unix socket is an optional optimization
+- Verify socket was created: `ls -la ~/.flutter_skill/servers/<id>.sock`
+- If it exists, the CLI will prefer it automatically; if not, TCP is used as fallback
+
+### Permission denied when accessing `~/.flutter_skill/servers/`
+
+**Problem**: Registry directory or files have restrictive permissions.
+
+**Solution**:
+1. Check permissions: `ls -la ~/.flutter_skill/servers/`
+2. Ensure your user owns the directory: `chown -R $(whoami) ~/.flutter_skill`
+3. Ensure readability: `chmod 700 ~/.flutter_skill` and `chmod 600 ~/.flutter_skill/servers/*`
+
+### Stale servers accumulate over time
+
+**Problem**: Registrations are building up even though the servers aren't running.
+
+**Solution**:
+- This shouldn't happen (stale entries are auto-cleaned when you list)
+- But if it does, manually clean up:
+  ```bash
+  rm ~/.flutter_skill/servers/*.json ~/.flutter_skill/servers/*.sock 2>/dev/null
+  flutter_skill server list  # Verify they're gone
+  ```
+
+---
+
+## Best Practices
+
+1. **Always give servers meaningful names**: Use `--id=feature-auth` instead of `--id=app1`. Makes logs and debugging much easier.
+
+2. **Use `--detach` in CI/CD**: Non-interactive environments should detach the server so tests can run unattended.
+
+3. **Prefer explicit `--server=<id>`**: While auto-discovery works, explicitly naming the server makes scripts more maintainable and less ambiguous.
+
+4. **Monitor servers during development**: Use `flutter_skill server list` periodically to see what's running and clean up old servers if needed.
+
+5. **Combine with logging**: Redirect logs to files for debugging:
+   ```bash
+   flutter_skill connect --id=myapp --port=50000 > server.log 2>&1 &
+   ```
+
+6. **Use `--output=json` in scripts**: When parsing output programmatically, always use `--output=json` to get structured results.
+
+7. **Handle parallel failures gracefully**: When using `--server=a,b,c`, individual failures don't stop the entire command. Check the exit code (1 if any failed) and parse JSON results to identify which ones failed.
+
+8. **Clean up on exit**: In CI pipelines, always use `flutter_skill server stop` in a cleanup step (or `if: always()` block) to prevent resource leaks.

--- a/docs/cli-server-commands.md
+++ b/docs/cli-server-commands.md
@@ -359,6 +359,52 @@ Identical to `flutter_skill server list`. Useful for quick checks.
 
 ---
 
+### `flutter_skill ping`
+
+**Quick health check for one or more named server instances.**
+
+```bash
+flutter_skill ping --server=<id>[,<id2>,...] [--output=json|human]
+```
+
+Sends a `ping` request to each named server and reports whether it responded.
+Exits with code 0 if all servers are reachable, or 1 if any are unreachable.
+
+#### Examples
+
+```bash
+# Check a single server
+flutter_skill ping --server=myapp
+
+# Check multiple servers
+flutter_skill ping --server=feature-auth,feature-payments
+
+# JSON output (useful for scripting and CI)
+flutter_skill ping --server=ci-test --output=json
+```
+
+#### Output (Human)
+
+```
+[myapp] pong (12ms)
+```
+
+#### Output (Human, Unreachable)
+
+```
+[myapp] unreachable: Could not connect to server "myapp": Connection refused
+```
+
+#### Output (JSON)
+
+```json
+[
+  {"server": "myapp", "success": true, "action": "ping", "duration_ms": 12}
+]
+```
+
+---
+
 ### `flutter_skill inspect`
 
 **Inspect the interactive elements of a Flutter app.**
@@ -651,7 +697,7 @@ jobs:
       - name: Wait for app readiness
         run: |
           for i in {1..30}; do
-            if flutter_skill ping --server=ci-test 2>/dev/null; then
+            if flutter_skill ping --server=ci-test --output=json 2>/dev/null; then
               echo "App is ready"
               exit 0
             fi

--- a/lib/src/cli/act.dart
+++ b/lib/src/cli/act.dart
@@ -219,6 +219,47 @@ Map<String, dynamic> _buildRpcCall(List<String> actArgs) {
       };
     case 'go_back':
       return {'method': 'go_back', 'params': {}};
+    case 'assert_visible':
+      return {
+        'method': 'assert_visible',
+        'params': {
+          if (param1 != null) 'key': param1,
+        }
+      };
+    case 'assert_gone':
+      return {
+        'method': 'assert_gone',
+        'params': {
+          if (param1 != null) 'key': param1,
+        }
+      };
+    case 'wait_for':
+    case 'wait_for_element':
+      return {
+        'method': 'wait_for_element',
+        'params': {
+          if (param1 != null) 'key': param1,
+          if (param2 != null) 'timeout': int.tryParse(param2) ?? 5000,
+        }
+      };
+    case 'get_text':
+      return {
+        'method': 'get_text',
+        'params': {
+          if (param1 != null) 'key': param1,
+        }
+      };
+    case 'find_element':
+      return {
+        'method': 'find_element',
+        'params': {
+          if (param1 != null) 'key': param1,
+        }
+      };
+    case 'hot_reload':
+      return {'method': 'hot_reload', 'params': {}};
+    case 'hot_restart':
+      return {'method': 'hot_restart', 'params': {}};
     default:
       return {'method': action, 'params': {}};
   }
@@ -241,8 +282,12 @@ Future<void> _actViaServers(
       if (r.success) {
         final image = r.data?['image'] as String?;
         if (image != null) {
+          // For multiple servers, suffix the filename with the server ID.
+          final serverPath = serverIds.length > 1
+              ? _deriveServerPath(path, r.serverId)
+              : path;
           final bytes = base64Decode(image);
-          await File(path).writeAsBytes(bytes);
+          await File(serverPath).writeAsBytes(bytes);
         }
       }
     }
@@ -263,6 +308,16 @@ Future<void> _actViaServers(
 
   // Exit with error code if any server failed.
   if (results.any((r) => !r.success)) exit(1);
+}
+
+/// Derive a per-server output path by inserting the server ID before the
+/// file extension. For example:
+///   _deriveServerPath('screenshots/login.png', 'app-a')
+///   → 'screenshots/login_app-a.png'
+String _deriveServerPath(String path, String serverId) {
+  final dot = path.lastIndexOf('.');
+  if (dot == -1) return '${path}_$serverId';
+  return '${path.substring(0, dot)}_$serverId${path.substring(dot)}';
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/src/cli/act.dart
+++ b/lib/src/cli/act.dart
@@ -6,9 +6,9 @@ import 'output_format.dart';
 
 Future<void> runAct(List<String> args) async {
   // --server=<id>[,<id2>,...] — forward to named SkillServer instance(s)
-  final serverIds = _parseServerIds(args);
+  final serverIds = parseServerIds(args);
   final format = resolveOutputFormat(args);
-  final effectiveArgs = stripOutputFlag(args)
+  final effectiveArgs = stripOutputFormatFlag(args)
       .where((a) => !a.startsWith('--server='))
       .toList();
 
@@ -175,21 +175,6 @@ Future<void> runAct(List<String> args) async {
 // Server-forwarding helpers
 // ---------------------------------------------------------------------------
 
-/// Parse `--server=<id>[,<id2>,...]` from args and return the list of IDs.
-List<String> _parseServerIds(List<String> args) {
-  for (final arg in args) {
-    if (arg.startsWith('--server=')) {
-      final value = arg.substring('--server='.length);
-      return value
-          .split(',')
-          .map((s) => s.trim())
-          .where((s) => s.isNotEmpty)
-          .toList();
-    }
-  }
-  return [];
-}
-
 /// Build a JSON-RPC method name + params from the act CLI args.
 Map<String, dynamic> _buildRpcCall(List<String> actArgs) {
   if (actArgs.isEmpty) return {'method': 'ping', 'params': {}};
@@ -210,10 +195,17 @@ Map<String, dynamic> _buildRpcCall(List<String> actArgs) {
         'params': {'key': param1, 'text': param2 ?? ''}
       };
     case 'scroll':
-    case 'scroll_to':
       return {
         'method': 'swipe',
-        'params': {'direction': 'up', 'key': param1}
+        'params': {
+          'direction': param1 ?? 'up', // param1 IS the direction for `scroll`
+          'distance': double.tryParse(param2 ?? '') ?? 300,
+        }
+      };
+    case 'scroll_to':
+      return {
+        'method': 'scroll_to',
+        'params': {'key': param1, 'direction': param2 ?? 'down'}
       };
     case 'screenshot':
       return {
@@ -259,14 +251,14 @@ Future<void> _actViaServers(
         }
       }
 
-      return _ActResult(
+      return ServerCallResult(
           serverId: id,
           success: true,
           action: action,
           durationMs: stopwatch.elapsedMilliseconds);
     } catch (e) {
       stopwatch.stop();
-      return _ActResult(
+      return ServerCallResult(
           serverId: id,
           success: false,
           action: action,
@@ -292,30 +284,6 @@ Future<void> _actViaServers(
 
   // Exit with error code if any server failed.
   if (results.any((r) => !r.success)) exit(1);
-}
-
-class _ActResult {
-  final String serverId;
-  final bool success;
-  final String action;
-  final String? error;
-  final int durationMs;
-
-  const _ActResult({
-    required this.serverId,
-    required this.success,
-    required this.action,
-    this.error,
-    required this.durationMs,
-  });
-
-  Map<String, dynamic> toJson() => {
-        'server': serverId,
-        'success': success,
-        'action': action,
-        if (error != null) 'error': error,
-        'duration_ms': durationMs,
-      };
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/src/cli/act.dart
+++ b/lib/src/cli/act.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 import '../drivers/flutter_driver.dart';
-import '../skill_client.dart';
 import 'output_format.dart';
 
 Future<void> runAct(List<String> args) async {
@@ -195,12 +194,10 @@ Map<String, dynamic> _buildRpcCall(List<String> actArgs) {
         'params': {'key': param1, 'text': param2 ?? ''}
       };
     case 'scroll':
+      // param1 = widget key/text to scroll to (matches direct VM path semantics)
       return {
-        'method': 'swipe',
-        'params': {
-          'direction': param1 ?? 'up', // param1 IS the direction for `scroll`
-          'distance': double.tryParse(param2 ?? '') ?? 300,
-        }
+        'method': 'scroll_to',
+        'params': {'key': param1}
       };
     case 'scroll_to':
       return {
@@ -234,40 +231,22 @@ Future<void> _actViaServers(
   final params = rpc['params'] as Map<String, dynamic>;
   final action = actArgs.isNotEmpty ? actArgs[0] : method;
 
-  final futures = serverIds.map((id) async {
-    final stopwatch = Stopwatch()..start();
-    try {
-      final client = SkillClient.byId(id);
-      final result = await client.call(method, params);
-      stopwatch.stop();
+  final results =
+      await callServersParallel(serverIds, method, params, actionLabel: action);
 
-      // Handle screenshot save when --server is used.
-      if (method == 'screenshot' && actArgs.length > 1) {
-        final path = actArgs[1];
-        final image = result['image'] as String?;
+  // Handle screenshot save when --server is used (specific to this action).
+  if (method == 'screenshot' && actArgs.length > 1) {
+    final path = actArgs[1];
+    for (final r in results) {
+      if (r.success) {
+        final image = r.data?['image'] as String?;
         if (image != null) {
           final bytes = base64Decode(image);
           await File(path).writeAsBytes(bytes);
         }
       }
-
-      return ServerCallResult(
-          serverId: id,
-          success: true,
-          action: action,
-          durationMs: stopwatch.elapsedMilliseconds);
-    } catch (e) {
-      stopwatch.stop();
-      return ServerCallResult(
-          serverId: id,
-          success: false,
-          action: action,
-          error: e.toString(),
-          durationMs: stopwatch.elapsedMilliseconds);
     }
-  });
-
-  final results = await Future.wait(futures);
+  }
 
   if (format == OutputFormat.json) {
     print(jsonEncode(results.map((r) => r.toJson()).toList()));

--- a/lib/src/cli/act.dart
+++ b/lib/src/cli/act.dart
@@ -1,15 +1,30 @@
 import 'dart:convert';
 import 'dart:io';
 import '../drivers/flutter_driver.dart';
+import '../skill_client.dart';
+import 'output_format.dart';
 
 Future<void> runAct(List<String> args) async {
+  // --server=<id>[,<id2>,...] — forward to named SkillServer instance(s)
+  final serverIds = _parseServerIds(args);
+  final format = resolveOutputFormat(args);
+  final effectiveArgs = stripOutputFlag(args)
+      .where((a) => !a.startsWith('--server='))
+      .toList();
+
+  if (serverIds.isNotEmpty) {
+    await _actViaServers(serverIds, effectiveArgs, format);
+    return;
+  }
+
   String uri;
   int argOffset;
 
   // Check if first arg is a URI
-  if (args.isNotEmpty &&
-      (args[0].startsWith('ws://') || args[0].startsWith('http://'))) {
-    uri = args[0];
+  if (effectiveArgs.isNotEmpty &&
+      (effectiveArgs[0].startsWith('ws://') ||
+          effectiveArgs[0].startsWith('http://'))) {
+    uri = effectiveArgs[0];
     argOffset = 1;
   } else {
     // Use auto-discovery (no need for .flutter_skill_uri file!)
@@ -22,19 +37,19 @@ Future<void> runAct(List<String> args) async {
     }
   }
 
-  if (args.length <= argOffset) {
+  if (effectiveArgs.length <= argOffset) {
     print('Missing action argument');
     print('Usage: flutter_skill act [vm-uri] <action> <params...>');
     exit(1);
   }
 
-  String action = args[argOffset];
+  String action = effectiveArgs[argOffset];
   final client = FlutterSkillClient(uri);
 
   String? param1;
   String? param2;
-  if (args.length > argOffset + 1) param1 = args[argOffset + 1];
-  if (args.length > argOffset + 2) param2 = args[argOffset + 2];
+  if (effectiveArgs.length > argOffset + 1) param1 = effectiveArgs[argOffset + 1];
+  if (effectiveArgs.length > argOffset + 2) param2 = effectiveArgs[argOffset + 2];
 
   try {
     await client.connect();
@@ -155,6 +170,157 @@ Future<void> runAct(List<String> args) async {
     await client.disconnect();
   }
 }
+
+// ---------------------------------------------------------------------------
+// Server-forwarding helpers
+// ---------------------------------------------------------------------------
+
+/// Parse `--server=<id>[,<id2>,...]` from args and return the list of IDs.
+List<String> _parseServerIds(List<String> args) {
+  for (final arg in args) {
+    if (arg.startsWith('--server=')) {
+      final value = arg.substring('--server='.length);
+      return value
+          .split(',')
+          .map((s) => s.trim())
+          .where((s) => s.isNotEmpty)
+          .toList();
+    }
+  }
+  return [];
+}
+
+/// Build a JSON-RPC method name + params from the act CLI args.
+Map<String, dynamic> _buildRpcCall(List<String> actArgs) {
+  if (actArgs.isEmpty) return {'method': 'ping', 'params': {}};
+
+  final action = actArgs[0];
+  final param1 = actArgs.length > 1 ? actArgs[1] : null;
+  final param2 = actArgs.length > 2 ? actArgs[2] : null;
+
+  switch (action) {
+    case 'tap':
+      return {
+        'method': 'tap',
+        'params': {'key': param1}
+      };
+    case 'enter_text':
+      return {
+        'method': 'enter_text',
+        'params': {'key': param1, 'text': param2 ?? ''}
+      };
+    case 'scroll':
+    case 'scroll_to':
+      return {
+        'method': 'swipe',
+        'params': {'direction': 'up', 'key': param1}
+      };
+    case 'screenshot':
+      return {
+        'method': 'screenshot',
+        'params': param1 != null ? {'path': param1} : <String, dynamic>{}
+      };
+    case 'swipe':
+      return {
+        'method': 'swipe',
+        'params': {
+          'direction': param1 ?? 'up',
+          'distance': double.tryParse(param2 ?? '') ?? 300,
+        }
+      };
+    case 'go_back':
+      return {'method': 'go_back', 'params': {}};
+    default:
+      return {'method': action, 'params': {}};
+  }
+}
+
+Future<void> _actViaServers(
+    List<String> serverIds, List<String> actArgs, OutputFormat format) async {
+  final rpc = _buildRpcCall(actArgs);
+  final method = rpc['method'] as String;
+  final params = rpc['params'] as Map<String, dynamic>;
+  final action = actArgs.isNotEmpty ? actArgs[0] : method;
+
+  final futures = serverIds.map((id) async {
+    final stopwatch = Stopwatch()..start();
+    try {
+      final client = SkillClient.byId(id);
+      final result = await client.call(method, params);
+      stopwatch.stop();
+
+      // Handle screenshot save when --server is used.
+      if (method == 'screenshot' && actArgs.length > 1) {
+        final path = actArgs[1];
+        final image = result['image'] as String?;
+        if (image != null) {
+          final bytes = base64Decode(image);
+          await File(path).writeAsBytes(bytes);
+        }
+      }
+
+      return _ActResult(
+          serverId: id,
+          success: true,
+          action: action,
+          durationMs: stopwatch.elapsedMilliseconds);
+    } catch (e) {
+      stopwatch.stop();
+      return _ActResult(
+          serverId: id,
+          success: false,
+          action: action,
+          error: e.toString(),
+          durationMs: stopwatch.elapsedMilliseconds);
+    }
+  });
+
+  final results = await Future.wait(futures);
+
+  if (format == OutputFormat.json) {
+    print(jsonEncode(results.map((r) => r.toJson()).toList()));
+    return;
+  }
+
+  for (final r in results) {
+    if (r.success) {
+      print('[${r.serverId}] ${r.action} completed (${r.durationMs}ms)');
+    } else {
+      print('[${r.serverId}] Error: ${r.error}');
+    }
+  }
+
+  // Exit with error code if any server failed.
+  if (results.any((r) => !r.success)) exit(1);
+}
+
+class _ActResult {
+  final String serverId;
+  final bool success;
+  final String action;
+  final String? error;
+  final int durationMs;
+
+  const _ActResult({
+    required this.serverId,
+    required this.success,
+    required this.action,
+    this.error,
+    required this.durationMs,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'server': serverId,
+        'success': success,
+        'action': action,
+        if (error != null) 'error': error,
+        'duration_ms': durationMs,
+      };
+}
+
+// ---------------------------------------------------------------------------
+// Existing helper (unchanged)
+// ---------------------------------------------------------------------------
 
 bool _findTarget(List<dynamic> elements, String target) {
   for (final e in elements) {

--- a/lib/src/cli/act.dart
+++ b/lib/src/cli/act.dart
@@ -57,28 +57,44 @@ Future<void> runAct(List<String> args) async {
       case 'tap':
         if (param1 == null) throw ArgumentError('tap requires a key or text');
         await client.tap(key: param1);
-        print('Tapped "$param1"');
+        if (format == OutputFormat.json) {
+          print(jsonEncode({'success': true, 'action': 'tap', 'target': param1}));
+        } else {
+          print('Tapped "$param1"');
+        }
         break;
 
       case 'enter_text':
         if (param1 == null || param2 == null)
           throw ArgumentError('enter_text requires key and text');
         await client.enterText(param1, param2);
-        print('Entered text "$param2" into "$param1"');
+        if (format == OutputFormat.json) {
+          print(jsonEncode({'success': true, 'action': 'enter_text', 'key': param1, 'text': param2}));
+        } else {
+          print('Entered text "$param2" into "$param1"');
+        }
         break;
 
       case 'scroll_to':
         if (param1 == null)
           throw ArgumentError('scroll_to requires a key or text');
         await client.scrollTo(key: param1);
-        print('Scrolled to "$param1"');
+        if (format == OutputFormat.json) {
+          print(jsonEncode({'success': true, 'action': 'scroll_to', 'target': param1}));
+        } else {
+          print('Scrolled to "$param1"');
+        }
         break;
 
       case 'scroll':
         if (param1 == null)
           throw ArgumentError('scroll requires a key or text to scroll to');
         await client.scrollTo(key: param1);
-        print('Scrolled to "$param1"');
+        if (format == OutputFormat.json) {
+          print(jsonEncode({'success': true, 'action': 'scroll', 'target': param1}));
+        } else {
+          print('Scrolled to "$param1"');
+        }
         break;
 
       case 'screenshot':
@@ -88,12 +104,24 @@ Future<void> runAct(List<String> args) async {
           if (param1 != null) {
             final bytes = base64Decode(image);
             await File(param1).writeAsBytes(bytes);
-            print('Screenshot saved to $param1 (${bytes.length} bytes)');
+            if (format == OutputFormat.json) {
+              print(jsonEncode({'success': true, 'action': 'screenshot', 'path': param1, 'bytes': bytes.length}));
+            } else {
+              print('Screenshot saved to $param1 (${bytes.length} bytes)');
+            }
           } else {
-            print('Screenshot captured (${image.length} base64 chars)');
+            if (format == OutputFormat.json) {
+              print(jsonEncode({'success': true, 'action': 'screenshot', 'base64Length': image.length}));
+            } else {
+              print('Screenshot captured (${image.length} base64 chars)');
+            }
           }
         } else {
-          print('Screenshot failed');
+          if (format == OutputFormat.json) {
+            print(jsonEncode({'success': false, 'error': 'Screenshot failed'}));
+          } else {
+            print('Screenshot failed');
+          }
           exit(1);
         }
         break;
@@ -101,14 +129,22 @@ Future<void> runAct(List<String> args) async {
       case 'get_text':
         if (param1 == null) throw ArgumentError('get_text requires a key');
         final text = await client.getTextValue(param1);
-        print(text ?? '(null)');
+        if (format == OutputFormat.json) {
+          print(jsonEncode({'success': true, 'action': 'get_text', 'key': param1, 'text': text}));
+        } else {
+          print(text ?? '(null)');
+        }
         break;
 
       case 'find_element':
         if (param1 == null)
           throw ArgumentError('find_element requires a key or text');
         final found = await client.waitForElement(key: param1, timeout: 2000);
-        print(found ? 'Found "$param1"' : 'Not found "$param1"');
+        if (format == OutputFormat.json) {
+          print(jsonEncode({'success': found, 'action': 'find_element', 'target': param1, 'found': found}));
+        } else {
+          print(found ? 'Found "$param1"' : 'Not found "$param1"');
+        }
         break;
 
       case 'wait_for_element':
@@ -117,13 +153,21 @@ Future<void> runAct(List<String> args) async {
         final timeout = param2 != null ? int.tryParse(param2) ?? 5000 : 5000;
         final appeared =
             await client.waitForElement(key: param1, timeout: timeout);
-        print(appeared ? 'Found "$param1"' : 'Timeout waiting for "$param1"');
+        if (format == OutputFormat.json) {
+          print(jsonEncode({'success': appeared, 'action': 'wait_for_element', 'target': param1, 'found': appeared}));
+        } else {
+          print(appeared ? 'Found "$param1"' : 'Timeout waiting for "$param1"');
+        }
         if (!appeared) exit(1);
         break;
 
       case 'go_back':
         await client.goBack();
-        print('Navigated back');
+        if (format == OutputFormat.json) {
+          print(jsonEncode({'success': true, 'action': 'go_back'}));
+        } else {
+          print('Navigated back');
+        }
         break;
 
       case 'swipe':
@@ -131,7 +175,11 @@ Future<void> runAct(List<String> args) async {
         final distance =
             param2 != null ? double.tryParse(param2) ?? 300 : 300.0;
         await client.swipe(direction: direction, distance: distance);
-        print('Swiped $direction by $distance');
+        if (format == OutputFormat.json) {
+          print(jsonEncode({'success': true, 'action': 'swipe', 'direction': direction, 'distance': distance}));
+        } else {
+          print('Swiped $direction by $distance');
+        }
         break;
 
       case 'assert_visible':
@@ -140,7 +188,11 @@ Future<void> runAct(List<String> args) async {
         final target = param1;
         final elements = await client.getInteractiveElements();
         if (_findTarget(elements, target)) {
-          print('Assertion Passed: "$target" is visible.');
+          if (format == OutputFormat.json) {
+            print(jsonEncode({'success': true, 'action': 'assert_visible', 'target': target, 'visible': true}));
+          } else {
+            print('Assertion Passed: "$target" is visible.');
+          }
         } else {
           throw Exception('Assertion Failed: "$target" is NOT visible.');
         }
@@ -152,18 +204,30 @@ Future<void> runAct(List<String> args) async {
         final target = param1;
         final elements = await client.getInteractiveElements();
         if (!_findTarget(elements, target)) {
-          print('Assertion Passed: "$target" is gone.');
+          if (format == OutputFormat.json) {
+            print(jsonEncode({'success': true, 'action': 'assert_gone', 'target': target, 'gone': true}));
+          } else {
+            print('Assertion Passed: "$target" is gone.');
+          }
         } else {
           throw Exception('Assertion Failed: "$target" is STILL visible.');
         }
         break;
 
       default:
-        print('Unknown action: $action');
+        if (format == OutputFormat.json) {
+          print(jsonEncode({'success': false, 'error': 'Unknown action: $action'}));
+        } else {
+          print('Unknown action: $action');
+        }
         exit(1);
     }
   } catch (e) {
-    print('Error: $e');
+    if (format == OutputFormat.json) {
+      print(jsonEncode({'success': false, 'error': e.toString()}));
+    } else {
+      print('Error: $e');
+    }
     exit(1);
   } finally {
     await client.disconnect();
@@ -202,7 +266,9 @@ Map<String, dynamic> _buildRpcCall(List<String> actArgs) {
     case 'scroll_to':
       return {
         'method': 'scroll_to',
-        'params': {'key': param1, 'direction': param2 ?? 'down'}
+        'params': {
+          if (param1 != null) 'key': param1,
+        }
       };
     case 'screenshot':
       return {
@@ -294,7 +360,16 @@ Future<void> _actViaServers(
   }
 
   if (format == OutputFormat.json) {
-    print(jsonEncode(results.map((r) => r.toJson()).toList()));
+    if (serverIds.length == 1) {
+      final r = results.first;
+      if (r.success) {
+        print(jsonEncode(r.data ?? {'success': true, 'action': r.action}));
+      } else {
+        print(jsonEncode({'success': false, 'error': r.error}));
+      }
+    } else {
+      print(jsonEncode(results.map((r) => r.toJson()).toList()));
+    }
     return;
   }
 

--- a/lib/src/cli/connect.dart
+++ b/lib/src/cli/connect.dart
@@ -42,6 +42,12 @@ Future<void> runConnect(List<String> args) async {
     exit(1);
   }
 
+  // Validate id early — before any expensive I/O.
+  if (!RegExp(r'^[a-zA-Z0-9_\-]+$').hasMatch(id)) {
+    print('Error: invalid server id "$id". Only letters, numbers, hyphens, and underscores are allowed.');
+    exit(1);
+  }
+
   // Build the WebSocket URI.
   if (uri == null) {
     if (port != null) {

--- a/lib/src/cli/connect.dart
+++ b/lib/src/cli/connect.dart
@@ -91,21 +91,26 @@ Future<void> runConnect(List<String> args) async {
   print('Press Ctrl+C to stop.');
 
   // Keep running until the process is interrupted.
+  var stopping = false;
   final shutdown = Completer<void>();
+
+  Future<void> doShutdown() async {
+    if (stopping) return;
+    stopping = true;
+    await server.stop().catchError((_) {});
+    await driver.disconnect().catchError((_) {});
+    if (!shutdown.isCompleted) shutdown.complete();
+  }
 
   ProcessSignal.sigint.watch().first.then((_) async {
     print('\nShutting down server "$id"...');
-    await server.stop();
-    await driver.disconnect();
-    shutdown.complete();
+    await doShutdown();
   });
 
   // Also handle SIGTERM on Unix.
   if (!Platform.isWindows) {
     ProcessSignal.sigterm.watch().first.then((_) async {
-      await server.stop();
-      await driver.disconnect();
-      if (!shutdown.isCompleted) shutdown.complete();
+      await doShutdown();
     });
   }
 

--- a/lib/src/cli/connect.dart
+++ b/lib/src/cli/connect.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import '../drivers/flutter_driver.dart';
@@ -62,6 +63,12 @@ Future<void> runConnect(List<String> args) async {
     if (!uri.endsWith('/ws')) uri = '$uri/ws';
   }
 
+  // Normalise https:// → wss://
+  if (uri.startsWith('https://')) {
+    uri = uri.replaceFirst('https://', 'wss://');
+    if (!uri.endsWith('/ws')) uri = '$uri/ws';
+  }
+
   print('Connecting to Flutter app at $uri...');
   final driver = FlutterSkillClient(uri);
   try {
@@ -84,11 +91,13 @@ Future<void> runConnect(List<String> args) async {
   print('Press Ctrl+C to stop.');
 
   // Keep running until the process is interrupted.
+  final shutdown = Completer<void>();
+
   ProcessSignal.sigint.watch().first.then((_) async {
     print('\nShutting down server "$id"...');
     await server.stop();
     await driver.disconnect();
-    exit(0);
+    shutdown.complete();
   });
 
   // Also handle SIGTERM on Unix.
@@ -96,10 +105,10 @@ Future<void> runConnect(List<String> args) async {
     ProcessSignal.sigterm.watch().first.then((_) async {
       await server.stop();
       await driver.disconnect();
-      exit(0);
+      if (!shutdown.isCompleted) shutdown.complete();
     });
   }
 
-  // Park the isolate so the process stays alive.
-  await Future<void>.delayed(const Duration(days: 365));
+  await shutdown.future;
+  exit(0);
 }

--- a/lib/src/cli/connect.dart
+++ b/lib/src/cli/connect.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import '../drivers/flutter_driver.dart';
+import '../skill_server.dart';
+
+/// CLI command: `flutter_skill connect --id=<name> [--port=<port>|--uri=<uri>]`
+///
+/// Attaches to a running Flutter app (identified by VM Service port or URI),
+/// wraps it in a [SkillServer], registers the server in the registry, and
+/// keeps running until Ctrl+C.
+Future<void> runConnect(List<String> args) async {
+  String? id;
+  int? port;
+  String? uri;
+  String projectPath = '.';
+  String deviceId = '';
+
+  for (final arg in args) {
+    if (arg.startsWith('--id=')) {
+      id = arg.substring('--id='.length);
+    } else if (arg.startsWith('--port=')) {
+      port = int.tryParse(arg.substring('--port='.length));
+    } else if (arg.startsWith('--uri=')) {
+      uri = arg.substring('--uri='.length);
+    } else if (arg.startsWith('--project=')) {
+      projectPath = arg.substring('--project='.length);
+    } else if (arg.startsWith('--device=')) {
+      deviceId = arg.substring('--device='.length);
+    }
+  }
+
+  if (id == null) {
+    print('Usage: flutter_skill connect --id=<name> [--port=<port>|--uri=<uri>]');
+    print('');
+    print('Options:');
+    print('  --id=<name>    Server name (required)');
+    print('  --port=<port>  VM Service port (e.g. 50000)');
+    print('  --uri=<uri>    VM Service URI (e.g. ws://127.0.0.1:50000/ws)');
+    print('  --project=<p>  Project path (for registry metadata)');
+    print('  --device=<d>   Device ID (for registry metadata)');
+    exit(1);
+  }
+
+  // Build the WebSocket URI.
+  if (uri == null) {
+    if (port != null) {
+      uri = 'ws://127.0.0.1:$port/ws';
+    } else {
+      // Fall back to auto-discovery.
+      try {
+        uri = await FlutterSkillClient.resolveUri([]);
+      } catch (e) {
+        print('Error: $e');
+        exit(1);
+      }
+    }
+  }
+
+  // Normalise http:// → ws://
+  if (uri.startsWith('http://')) {
+    uri = uri.replaceFirst('http://', 'ws://');
+    if (!uri.endsWith('/ws')) uri = '$uri/ws';
+  }
+
+  print('Connecting to Flutter app at $uri...');
+  final driver = FlutterSkillClient(uri);
+  try {
+    await driver.connect();
+  } catch (e) {
+    print('Failed to connect: $e');
+    exit(1);
+  }
+  print('Connected.');
+
+  final server = SkillServer(
+    id: id,
+    driver: driver,
+    projectPath: projectPath,
+    deviceId: deviceId,
+  );
+
+  await server.start();
+  print('Skill server "$id" listening on port ${server.port}');
+  print('Press Ctrl+C to stop.');
+
+  // Keep running until the process is interrupted.
+  ProcessSignal.sigint.watch().first.then((_) async {
+    print('\nShutting down server "$id"...');
+    await server.stop();
+    await driver.disconnect();
+    exit(0);
+  });
+
+  // Also handle SIGTERM on Unix.
+  if (!Platform.isWindows) {
+    ProcessSignal.sigterm.watch().first.then((_) async {
+      await server.stop();
+      await driver.disconnect();
+      exit(0);
+    });
+  }
+
+  // Park the isolate so the process stays alive.
+  await Future<void>.delayed(const Duration(days: 365));
+}

--- a/lib/src/cli/connect.dart
+++ b/lib/src/cli/connect.dart
@@ -57,16 +57,14 @@ Future<void> runConnect(List<String> args) async {
     }
   }
 
-  // Normalise http:// → ws://
+  // Normalise http:// → ws:// and https:// → wss://.
+  // Always use the /ws path regardless of any existing path component.
   if (uri.startsWith('http://')) {
-    uri = uri.replaceFirst('http://', 'ws://');
-    if (!uri.endsWith('/ws')) uri = '$uri/ws';
-  }
-
-  // Normalise https:// → wss://
-  if (uri.startsWith('https://')) {
-    uri = uri.replaceFirst('https://', 'wss://');
-    if (!uri.endsWith('/ws')) uri = '$uri/ws';
+    final parsed = Uri.parse(uri);
+    uri = 'ws://${parsed.host}:${parsed.port}/ws';
+  } else if (uri.startsWith('https://')) {
+    final parsed = Uri.parse(uri);
+    uri = 'wss://${parsed.host}:${parsed.port}/ws';
   }
 
   print('Connecting to Flutter app at $uri...');
@@ -113,6 +111,12 @@ Future<void> runConnect(List<String> args) async {
       await doShutdown();
     });
   }
+
+  // Listen for server-initiated shutdown (e.g. via `flutter_skill server stop`).
+  server.onShutdownRequested.listen((_) async {
+    print('\nServer "$id" received shutdown request.');
+    await doShutdown();
+  });
 
   await shutdown.future;
   exit(0);

--- a/lib/src/cli/inspect.dart
+++ b/lib/src/cli/inspect.dart
@@ -58,17 +58,29 @@ Future<void> _inspectViaServers(
   final results = await callServersParallel(serverIds, 'inspect', {});
 
   if (format == OutputFormat.json) {
-    print(jsonEncode(results.map((r) => r.toJson()).toList()));
+    if (serverIds.length == 1) {
+      // Single server: unwrap to match direct-VM schema {"elements": [...]}
+      final r = results.first;
+      if (r.success) {
+        print(jsonEncode(r.data ?? {'elements': []}));
+      } else {
+        print(jsonEncode({'error': r.error}));
+      }
+    } else {
+      print(jsonEncode(results.map((r) => r.toJson()).toList()));
+    }
     return;
   }
 
+  // Human output: always show server prefix for clarity
   for (final r in results) {
     if (!r.success) {
       print('[${r.serverId}] Error: ${r.error}');
       continue;
     }
-    final elements = (r.data!['elements'] as List?) ?? [];
-    print('[${r.serverId}] Interactive Elements (${r.durationMs}ms):');
+    final elements = (r.data?['elements'] as List?) ?? [];
+    final prefix = serverIds.length > 1 ? '[${r.serverId}] ' : '';
+    print('${prefix}Interactive Elements (${r.durationMs}ms):');
     if (elements.isEmpty) {
       print('  (No interactive elements found)');
     } else {

--- a/lib/src/cli/inspect.dart
+++ b/lib/src/cli/inspect.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 import '../drivers/flutter_driver.dart';
-import '../skill_client.dart';
 import 'output_format.dart';
 
 Future<void> runInspect(List<String> args) async {
@@ -56,28 +55,7 @@ Future<void> runInspect(List<String> args) async {
 /// Forward the inspect action to one or more named servers concurrently.
 Future<void> _inspectViaServers(
     List<String> serverIds, OutputFormat format) async {
-  final futures = serverIds.map((id) async {
-    final stopwatch = Stopwatch()..start();
-    try {
-      final client = SkillClient.byId(id);
-      final result = await client.call('inspect', {});
-      stopwatch.stop();
-      return ServerCallResult(
-          serverId: id,
-          success: true,
-          data: result,
-          durationMs: stopwatch.elapsedMilliseconds);
-    } catch (e) {
-      stopwatch.stop();
-      return ServerCallResult(
-          serverId: id,
-          success: false,
-          error: e.toString(),
-          durationMs: stopwatch.elapsedMilliseconds);
-    }
-  });
-
-  final results = await Future.wait(futures);
+  final results = await callServersParallel(serverIds, 'inspect', {});
 
   if (format == OutputFormat.json) {
     print(jsonEncode(results.map((r) => r.toJson()).toList()));

--- a/lib/src/cli/inspect.dart
+++ b/lib/src/cli/inspect.dart
@@ -7,10 +7,10 @@ import 'output_format.dart';
 Future<void> runInspect(List<String> args) async {
   // --server=<id>[,<id2>,...] — forward to named SkillServer instance(s)
   // --output=json|human       — output format
-  final serverIds = _parseServerIds(args);
+  final serverIds = parseServerIds(args);
   final format = resolveOutputFormat(args);
   final cleanArgs =
-      stripOutputFlag(args).where((a) => !a.startsWith('--server=')).toList();
+      stripOutputFormatFlag(args).where((a) => !a.startsWith('--server=')).toList();
 
   if (serverIds.isNotEmpty) {
     await _inspectViaServers(serverIds, format);
@@ -62,14 +62,14 @@ Future<void> _inspectViaServers(
       final client = SkillClient.byId(id);
       final result = await client.call('inspect', {});
       stopwatch.stop();
-      return _ServerResult(
+      return ServerCallResult(
           serverId: id,
           success: true,
           data: result,
           durationMs: stopwatch.elapsedMilliseconds);
     } catch (e) {
       stopwatch.stop();
-      return _ServerResult(
+      return ServerCallResult(
           serverId: id,
           success: false,
           error: e.toString(),
@@ -129,42 +129,3 @@ void _printElement(dynamic element, {String prefix = ''}) {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Parse `--server=<id>[,<id2>,...]` from args and return the list of IDs.
-List<String> _parseServerIds(List<String> args) {
-  for (final arg in args) {
-    if (arg.startsWith('--server=')) {
-      final value = arg.substring('--server='.length);
-      return value.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
-    }
-  }
-  return [];
-}
-
-/// Holds the outcome of a single per-server parallel action.
-class _ServerResult {
-  final String serverId;
-  final bool success;
-  final Map<String, dynamic>? data;
-  final String? error;
-  final int durationMs;
-
-  const _ServerResult({
-    required this.serverId,
-    required this.success,
-    this.data,
-    this.error,
-    required this.durationMs,
-  });
-
-  Map<String, dynamic> toJson() => {
-        'server': serverId,
-        'success': success,
-        if (data != null) 'data': data,
-        if (error != null) 'error': error,
-        'duration_ms': durationMs,
-      };
-}

--- a/lib/src/cli/inspect.dart
+++ b/lib/src/cli/inspect.dart
@@ -1,13 +1,26 @@
+import 'dart:convert';
 import 'dart:io';
 import '../drivers/flutter_driver.dart';
+import '../skill_client.dart';
+import 'output_format.dart';
 
 Future<void> runInspect(List<String> args) async {
-  // No initial arg check, let resolveUri handle it
-  // if (args.isEmpty) ...
+  // --server=<id>[,<id2>,...] — forward to named SkillServer instance(s)
+  // --output=json|human       — output format
+  final serverIds = _parseServerIds(args);
+  final format = resolveOutputFormat(args);
+  final cleanArgs =
+      stripOutputFlag(args).where((a) => !a.startsWith('--server=')).toList();
 
+  if (serverIds.isNotEmpty) {
+    await _inspectViaServers(serverIds, format);
+    return;
+  }
+
+  // Default behaviour: direct VM Service connection.
   String uri;
   try {
-    uri = await FlutterSkillClient.resolveUri(args);
+    uri = await FlutterSkillClient.resolveUri(cleanArgs);
   } catch (e) {
     print(e);
     exit(1);
@@ -19,13 +32,17 @@ Future<void> runInspect(List<String> args) async {
     await client.connect();
     final elements = await client.getInteractiveElements();
 
-    // Print simplified tree for LLM consumption
-    print('Interactive Elements:');
-    if (elements.isEmpty) {
-      print('(No interactive elements found)');
+    if (format == OutputFormat.json) {
+      print(jsonEncode({'elements': elements}));
     } else {
-      for (final e in elements) {
-        _printElement(e);
+      // Print simplified tree for LLM consumption
+      print('Interactive Elements:');
+      if (elements.isEmpty) {
+        print('(No interactive elements found)');
+      } else {
+        for (final e in elements) {
+          _printElement(e);
+        }
       }
     }
   } catch (e) {
@@ -36,7 +53,55 @@ Future<void> runInspect(List<String> args) async {
   }
 }
 
-void _printElement(dynamic element, [String prefix = '']) {
+/// Forward the inspect action to one or more named servers concurrently.
+Future<void> _inspectViaServers(
+    List<String> serverIds, OutputFormat format) async {
+  final futures = serverIds.map((id) async {
+    final stopwatch = Stopwatch()..start();
+    try {
+      final client = SkillClient.byId(id);
+      final result = await client.call('inspect', {});
+      stopwatch.stop();
+      return _ServerResult(
+          serverId: id,
+          success: true,
+          data: result,
+          durationMs: stopwatch.elapsedMilliseconds);
+    } catch (e) {
+      stopwatch.stop();
+      return _ServerResult(
+          serverId: id,
+          success: false,
+          error: e.toString(),
+          durationMs: stopwatch.elapsedMilliseconds);
+    }
+  });
+
+  final results = await Future.wait(futures);
+
+  if (format == OutputFormat.json) {
+    print(jsonEncode(results.map((r) => r.toJson()).toList()));
+    return;
+  }
+
+  for (final r in results) {
+    if (!r.success) {
+      print('[${r.serverId}] Error: ${r.error}');
+      continue;
+    }
+    final elements = (r.data!['elements'] as List?) ?? [];
+    print('[${r.serverId}] Interactive Elements (${r.durationMs}ms):');
+    if (elements.isEmpty) {
+      print('  (No interactive elements found)');
+    } else {
+      for (final e in elements) {
+        _printElement(e, prefix: '  ');
+      }
+    }
+  }
+}
+
+void _printElement(dynamic element, {String prefix = ''}) {
   if (element is! Map) return;
 
   // Try to extract useful info
@@ -59,7 +124,47 @@ void _printElement(dynamic element, [String prefix = '']) {
   // Recursively print children if any
   if (element.containsKey('children') && element['children'] is List) {
     for (final child in element['children']) {
-      _printElement(child, '$prefix  ');
+      _printElement(child, prefix: '$prefix  ');
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parse `--server=<id>[,<id2>,...]` from args and return the list of IDs.
+List<String> _parseServerIds(List<String> args) {
+  for (final arg in args) {
+    if (arg.startsWith('--server=')) {
+      final value = arg.substring('--server='.length);
+      return value.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+    }
+  }
+  return [];
+}
+
+/// Holds the outcome of a single per-server parallel action.
+class _ServerResult {
+  final String serverId;
+  final bool success;
+  final Map<String, dynamic>? data;
+  final String? error;
+  final int durationMs;
+
+  const _ServerResult({
+    required this.serverId,
+    required this.success,
+    this.data,
+    this.error,
+    required this.durationMs,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'server': serverId,
+        'success': success,
+        if (data != null) 'data': data,
+        if (error != null) 'error': error,
+        'duration_ms': durationMs,
+      };
 }

--- a/lib/src/cli/launch.dart
+++ b/lib/src/cli/launch.dart
@@ -140,15 +140,20 @@ void _attachServer(String id, String uri, String projectPath, Process process) a
 void _spawnDetachedServer(String id, String uri, String projectPath) {
   // We re-invoke ourselves with the `connect` command so the child process
   // manages the server lifecycle independently.
-  final exe = Platform.resolvedExecutable;
+  final exe = Platform.executable; // The binary that was actually invoked.
   final script = Platform.script.toFilePath();
 
-  // When running via `dart run`, resolvedExecutable is the Dart VM binary.
-  // Re-invoke as: dart <script> connect ...
+  // When running via `dart run` or `dart <script>`, executable is the Dart VM
+  // binary. Re-invoke as: dart <script> connect ...
   // When compiled/globally activated, exe IS the flutter_skill binary.
   final List<String> cmdArgs;
   if (exe.endsWith('dart') || exe.endsWith('dart.exe')) {
-    cmdArgs = [script, 'connect', '--id=$id', '--uri=$uri', '--project=$projectPath'];
+    if (script.isNotEmpty && script.endsWith('.dart')) {
+      cmdArgs = [script, 'connect', '--id=$id', '--uri=$uri', '--project=$projectPath'];
+    } else {
+      // Snapshot or other — best effort.
+      cmdArgs = ['run', 'bin/flutter_skill.dart', 'connect', '--id=$id', '--uri=$uri', '--project=$projectPath'];
+    }
   } else {
     cmdArgs = ['connect', '--id=$id', '--uri=$uri', '--project=$projectPath'];
   }

--- a/lib/src/cli/launch.dart
+++ b/lib/src/cli/launch.dart
@@ -68,7 +68,7 @@ Future<void> runLaunch(List<String> args) async {
     final uri = _extractUri(line);
     if (uri != null && discoveredUri == null) {
       discoveredUri = uri;
-      _onUriDiscovered(uri, serverId, projectPath, detach);
+      _onUriDiscovered(uri, serverId, projectPath, detach, process);
     }
   });
 
@@ -97,7 +97,7 @@ String? _extractUri(String line) {
 }
 
 void _onUriDiscovered(
-    String uri, String? serverId, String projectPath, bool detach) {
+    String uri, String? serverId, String projectPath, bool detach, Process process) {
   print('\nFlutter Skill: VM Service is ready');
   print('   URI: $uri');
   print('   Run: flutter_skill inspect  (auto-discovery)');
@@ -110,12 +110,12 @@ void _onUriDiscovered(
     _spawnDetachedServer(serverId, uri, projectPath);
   } else {
     // Attach the SkillServer in-process (background isolate via async).
-    _attachServer(serverId, uri, projectPath);
+    _attachServer(serverId, uri, projectPath, process);
   }
 }
 
 /// Attach a SkillServer in the same process (async, non-blocking).
-void _attachServer(String id, String uri, String projectPath) async {
+void _attachServer(String id, String uri, String projectPath, Process process) async {
   try {
     final driver = FlutterSkillClient(uri);
     await driver.connect();
@@ -126,6 +126,11 @@ void _attachServer(String id, String uri, String projectPath) async {
     // Write a convenience file in the project directory.
     final marker = File('$projectPath/.flutter_skill_server');
     await marker.writeAsString(id, flush: true);
+
+    // Stop the skill server when flutter run exits.
+    process.exitCode.then((_) async {
+      await server.stop().catchError((_) {});
+    });
   } catch (e) {
     print('Warning: Could not start skill server "$id": $e');
   }

--- a/lib/src/cli/launch.dart
+++ b/lib/src/cli/launch.dart
@@ -135,9 +135,22 @@ void _attachServer(String id, String uri, String projectPath) async {
 void _spawnDetachedServer(String id, String uri, String projectPath) {
   // We re-invoke ourselves with the `connect` command so the child process
   // manages the server lifecycle independently.
+  final exe = Platform.resolvedExecutable;
+  final script = Platform.script.toFilePath();
+
+  // When running via `dart run`, resolvedExecutable is the Dart VM binary.
+  // Re-invoke as: dart <script> connect ...
+  // When compiled/globally activated, exe IS the flutter_skill binary.
+  final List<String> cmdArgs;
+  if (exe.endsWith('dart') || exe.endsWith('dart.exe')) {
+    cmdArgs = [script, 'connect', '--id=$id', '--uri=$uri', '--project=$projectPath'];
+  } else {
+    cmdArgs = ['connect', '--id=$id', '--uri=$uri', '--project=$projectPath'];
+  }
+
   Process.start(
-    Platform.resolvedExecutable,
-    ['connect', '--id=$id', '--uri=$uri', '--project=$projectPath'],
+    exe,
+    cmdArgs,
     mode: ProcessStartMode.detached,
     runInShell: false,
   ).then((p) {

--- a/lib/src/cli/launch.dart
+++ b/lib/src/cli/launch.dart
@@ -1,23 +1,32 @@
 import 'dart:convert';
 import 'dart:io';
 import 'setup.dart'; // Import setup logic
+import '../drivers/flutter_driver.dart';
+import '../skill_server.dart';
 
 Future<void> runLaunch(List<String> args) async {
-  // Extract project path. Everything else is passed to flutter run.
-  // We assume: flutter_skill launch [project_path] [flutter_args...]
-  // But wait, standard args might be tricky.
-  // Let's say: first arg is project path if it doesn't start with -?
+  // Extract project path and new flags before passing the rest to flutter run.
+  //
+  // New flags (consumed here, not forwarded to flutter):
+  //   --id=<name>    Register the attached skill server under this name.
+  //   --detach       Spawn a detached child process that keeps the server alive;
+  //                  the parent process exits after handing off.
 
   String projectPath = '.';
+  String? serverId;
+  bool detach = false;
   List<String> flutterArgs = [];
 
-  if (args.isNotEmpty) {
-    if (!args[0].startsWith('-')) {
-      projectPath = args[0];
-      flutterArgs = args.sublist(1);
+  for (int i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg.startsWith('--id=')) {
+      serverId = arg.substring('--id='.length);
+    } else if (arg == '--detach') {
+      detach = true;
+    } else if (i == 0 && !arg.startsWith('-')) {
+      projectPath = arg;
     } else {
-      // Current dir, all args are for flutter
-      flutterArgs = args;
+      flutterArgs.add(arg);
     }
   }
 
@@ -30,11 +39,11 @@ Future<void> runLaunch(List<String> args) async {
     print('Proceeding with launch anyway...');
   }
 
-  // Auto-add --vm-service-port=50000 if not specified
-  // This ensures faster discovery (recommended but not required)
+  // Auto-add --vm-service-port=50000 if not specified.
+  // This ensures faster discovery (recommended but not required).
   if (!flutterArgs.any((arg) => arg.contains('--vm-service-port'))) {
     flutterArgs.add('--vm-service-port=50000');
-    print('💡 Auto-adding --vm-service-port=50000 (推荐，可加速发现)');
+    print('Auto-adding --vm-service-port=50000 (recommended for faster discovery)');
   }
 
   print('Launching Flutter app in: $projectPath with args: $flutterArgs');
@@ -49,12 +58,18 @@ Future<void> runLaunch(List<String> args) async {
   print(
       'Flutter process started (PID: ${process.pid}). Waiting for connection URI...');
 
+  String? discoveredUri;
+
   process.stdout
       .transform(utf8.decoder)
       .transform(const LineSplitter())
       .listen((line) {
     print('[Flutter]: $line');
-    _checkForUri(line);
+    final uri = _extractUri(line);
+    if (uri != null && discoveredUri == null) {
+      discoveredUri = uri;
+      _onUriDiscovered(uri, serverId, projectPath, detach);
+    }
   });
 
   process.stderr
@@ -74,16 +89,62 @@ Future<void> runLaunch(List<String> args) async {
   exit(exitCode);
 }
 
-void _checkForUri(String line) {
-  if (line.contains('ws://')) {
-    final uriRegex = RegExp(r'ws://[^\s]+');
-    final match = uriRegex.firstMatch(line);
-    if (match != null) {
-      final uri = match.group(0)!;
-      print('\n✅ Flutter Skill: VM Service 已启动');
-      print('   URI: $uri');
-      print('   🚀 现在可以直接使用: flutter_skill inspect (自动发现)');
-      // Note: No longer saving to .flutter_skill_uri - using auto-discovery instead!
-    }
+String? _extractUri(String line) {
+  if (!line.contains('ws://')) return null;
+  final uriRegex = RegExp(r'ws://[^\s]+');
+  final match = uriRegex.firstMatch(line);
+  return match?.group(0);
+}
+
+void _onUriDiscovered(
+    String uri, String? serverId, String projectPath, bool detach) {
+  print('\nFlutter Skill: VM Service is ready');
+  print('   URI: $uri');
+  print('   Run: flutter_skill inspect  (auto-discovery)');
+
+  if (serverId == null) return;
+
+  if (detach) {
+    // Spawn a detached helper process that owns the SkillServer lifecycle.
+    // The parent (this process) continues owning `flutter run`.
+    _spawnDetachedServer(serverId, uri, projectPath);
+  } else {
+    // Attach the SkillServer in-process (background isolate via async).
+    _attachServer(serverId, uri, projectPath);
   }
+}
+
+/// Attach a SkillServer in the same process (async, non-blocking).
+void _attachServer(String id, String uri, String projectPath) async {
+  try {
+    final driver = FlutterSkillClient(uri);
+    await driver.connect();
+    final server = SkillServer(id: id, driver: driver, projectPath: projectPath);
+    await server.start();
+    print('Skill server "$id" listening on port ${server.port}');
+
+    // Write a convenience file in the project directory.
+    final marker = File('$projectPath/.flutter_skill_server');
+    await marker.writeAsString(id, flush: true);
+  } catch (e) {
+    print('Warning: Could not start skill server "$id": $e');
+  }
+}
+
+/// Spawn a completely detached child process to host the SkillServer.
+void _spawnDetachedServer(String id, String uri, String projectPath) {
+  // We re-invoke ourselves with the `connect` command so the child process
+  // manages the server lifecycle independently.
+  Process.start(
+    Platform.resolvedExecutable,
+    ['connect', '--id=$id', '--uri=$uri', '--project=$projectPath'],
+    mode: ProcessStartMode.detached,
+    runInShell: false,
+  ).then((p) {
+    print('Detached skill server "$id" started (PID: ${p.pid})');
+    final marker = File('$projectPath/.flutter_skill_server');
+    marker.writeAsString(id, flush: true).catchError((_) => marker);
+  }).catchError((e) {
+    print('Warning: Could not start detached server "$id": $e');
+  });
 }

--- a/lib/src/cli/launch.dart
+++ b/lib/src/cli/launch.dart
@@ -90,10 +90,12 @@ Future<void> runLaunch(List<String> args) async {
 }
 
 String? _extractUri(String line) {
-  if (!line.contains('ws://')) return null;
-  final uriRegex = RegExp(r'ws://[^\s]+');
-  final match = uriRegex.firstMatch(line);
-  return match?.group(0);
+  // Try ws:// first (most common)
+  final wsMatch = RegExp(r'ws://[^\s]+').firstMatch(line);
+  if (wsMatch != null) return wsMatch.group(0);
+  // Also match http:// VM Service URIs (newer Flutter versions)
+  final httpMatch = RegExp(r'http://127\.0\.0\.1:\d+[^\s]*').firstMatch(line);
+  return httpMatch?.group(0);
 }
 
 void _onUriDiscovered(

--- a/lib/src/cli/output_format.dart
+++ b/lib/src/cli/output_format.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+/// Returns true when the process is running inside a CI environment.
+///
+/// Checks common CI environment variables used by GitHub Actions, CircleCI,
+/// Travis CI, Buildkite, and generic CI setups.
+bool isCiEnvironment() =>
+    Platform.environment.containsKey('CI') ||
+    Platform.environment.containsKey('GITHUB_ACTIONS') ||
+    Platform.environment.containsKey('CIRCLECI') ||
+    Platform.environment.containsKey('TRAVIS') ||
+    Platform.environment.containsKey('BUILDKITE');
+
+/// The output format to use for CLI commands.
+enum OutputFormat { human, json }
+
+/// Resolve the output format from CLI args or environment.
+///
+/// [args] may contain `--output=json` or `--output=human`.
+/// Falls back to [isCiEnvironment] when no explicit flag is provided.
+OutputFormat resolveOutputFormat(List<String> args) {
+  for (final arg in args) {
+    if (arg == '--output=json') return OutputFormat.json;
+    if (arg == '--output=human') return OutputFormat.human;
+  }
+  return isCiEnvironment() ? OutputFormat.json : OutputFormat.human;
+}
+
+/// Strip `--output=*` entries from an arg list.
+List<String> stripOutputFlag(List<String> args) =>
+    args.where((a) => !a.startsWith('--output=')).toList();

--- a/lib/src/cli/output_format.dart
+++ b/lib/src/cli/output_format.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import '../skill_client.dart';
+
 /// Returns true when the process is running inside a CI environment.
 ///
 /// Checks common CI environment variables used by GitHub Actions, CircleCI,
@@ -30,9 +32,7 @@ OutputFormat resolveOutputFormat(List<String> args) {
 List<String> stripOutputFormatFlag(List<String> args) =>
     args.where((a) => !a.startsWith('--output=')).toList();
 
-/// Strip `--output=*` entries from an arg list.
-///
-/// Deprecated: use [stripOutputFormatFlag] for clarity.
+@Deprecated('Use stripOutputFormatFlag instead.')
 List<String> stripOutputFlag(List<String> args) => stripOutputFormatFlag(args);
 
 /// Parse `--server=<id>[,<id2>,...]` from args.
@@ -72,4 +72,36 @@ class ServerCallResult {
         if (error != null) 'error': error,
         'duration_ms': durationMs,
       };
+}
+
+/// Fan out a JSON-RPC call to multiple named servers concurrently.
+/// Returns one [ServerCallResult] per server.
+Future<List<ServerCallResult>> callServersParallel(
+    List<String> serverIds,
+    String method,
+    Map<String, dynamic> params,
+    {String? actionLabel}) async {
+  final futures = serverIds.map((id) async {
+    final sw = Stopwatch()..start();
+    try {
+      final client = SkillClient.byId(id);
+      final data = await client.call(method, params);
+      sw.stop();
+      return ServerCallResult(
+          serverId: id,
+          success: true,
+          action: actionLabel ?? method,
+          data: data,
+          durationMs: sw.elapsedMilliseconds);
+    } catch (e) {
+      sw.stop();
+      return ServerCallResult(
+          serverId: id,
+          success: false,
+          action: actionLabel ?? method,
+          error: e.toString(),
+          durationMs: sw.elapsedMilliseconds);
+    }
+  });
+  return Future.wait(futures);
 }

--- a/lib/src/cli/output_format.dart
+++ b/lib/src/cli/output_format.dart
@@ -27,5 +27,49 @@ OutputFormat resolveOutputFormat(List<String> args) {
 }
 
 /// Strip `--output=*` entries from an arg list.
-List<String> stripOutputFlag(List<String> args) =>
+List<String> stripOutputFormatFlag(List<String> args) =>
     args.where((a) => !a.startsWith('--output=')).toList();
+
+/// Strip `--output=*` entries from an arg list.
+///
+/// Deprecated: use [stripOutputFormatFlag] for clarity.
+List<String> stripOutputFlag(List<String> args) => stripOutputFormatFlag(args);
+
+/// Parse `--server=<id>[,<id2>,...]` from args.
+List<String> parseServerIds(List<String> args) {
+  for (final arg in args) {
+    if (arg.startsWith('--server=')) {
+      final value = arg.substring('--server='.length);
+      return value.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+    }
+  }
+  return [];
+}
+
+/// Holds the outcome of a single per-server parallel action.
+class ServerCallResult {
+  final String serverId;
+  final bool success;
+  final String? action;
+  final Map<String, dynamic>? data;
+  final String? error;
+  final int durationMs;
+
+  const ServerCallResult({
+    required this.serverId,
+    required this.success,
+    this.action,
+    this.data,
+    this.error,
+    required this.durationMs,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'server': serverId,
+        'success': success,
+        if (action != null) 'action': action,
+        if (data != null) 'data': data,
+        if (error != null) 'error': error,
+        'duration_ms': durationMs,
+      };
+}

--- a/lib/src/cli/output_format.dart
+++ b/lib/src/cli/output_format.dart
@@ -32,9 +32,6 @@ OutputFormat resolveOutputFormat(List<String> args) {
 List<String> stripOutputFormatFlag(List<String> args) =>
     args.where((a) => !a.startsWith('--output=')).toList();
 
-@Deprecated('Use stripOutputFormatFlag instead.')
-List<String> stripOutputFlag(List<String> args) => stripOutputFormatFlag(args);
-
 /// Parse `--server=<id>[,<id2>,...]` from args.
 List<String> parseServerIds(List<String> args) {
   for (final arg in args) {

--- a/lib/src/cli/ping_cmd.dart
+++ b/lib/src/cli/ping_cmd.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'output_format.dart';
+
+/// Run the `flutter_skill ping` command.
+///
+/// Usage: flutter_skill ping --server=<id>[,<id2>,...]
+///
+/// Sends a ping request to one or more named skill servers and prints the
+/// result. Exits with code 1 if any server is unreachable.
+Future<void> runPing(List<String> args) async {
+  final serverIds = parseServerIds(args);
+  if (serverIds.isEmpty) {
+    print('Usage: flutter_skill ping --server=<id>[,<id2>,...]');
+    exit(1);
+  }
+  final results = await callServersParallel(serverIds, 'ping', {});
+  final format = resolveOutputFormat(args);
+  if (format == OutputFormat.json) {
+    print(jsonEncode(results.map((r) => r.toJson()).toList()));
+  } else {
+    for (final r in results) {
+      if (r.success) {
+        print('[${r.serverId}] pong (${r.durationMs}ms)');
+      } else {
+        print('[${r.serverId}] unreachable: ${r.error}');
+      }
+    }
+  }
+  if (results.any((r) => !r.success)) exit(1);
+}

--- a/lib/src/cli/server_cmd.dart
+++ b/lib/src/cli/server_cmd.dart
@@ -1,0 +1,158 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../server_registry.dart';
+import '../skill_client.dart';
+import 'output_format.dart';
+
+/// CLI command: `flutter_skill server <subcommand> [options]`
+///
+/// Subcommands:
+///   list                        — table of running named servers
+///   stop  --id=<name>           — stop a named server
+///   status --id=<name>          — show status of a named server
+Future<void> runServerCmd(List<String> args) async {
+  final format = resolveOutputFormat(args);
+  final cleanArgs = stripOutputFlag(args);
+
+  final sub = cleanArgs.isNotEmpty ? cleanArgs[0] : 'list';
+  final subArgs = cleanArgs.length > 1 ? cleanArgs.sublist(1) : <String>[];
+
+  switch (sub) {
+    case 'list':
+      await _cmdList(format);
+      break;
+    case 'stop':
+      await _cmdStop(subArgs, format);
+      break;
+    case 'status':
+      await _cmdStatus(subArgs, format);
+      break;
+    default:
+      print('Unknown server subcommand: $sub');
+      print('Available: list, stop, status');
+      exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+Future<void> _cmdList(OutputFormat format) async {
+  final entries = await ServerRegistry.listAll();
+
+  if (format == OutputFormat.json) {
+    print(jsonEncode(entries.map((e) => e.toJson()).toList()));
+    return;
+  }
+
+  if (entries.isEmpty) {
+    print('No running skill servers found.');
+    return;
+  }
+
+  // Human-readable table.
+  print('Running skill servers:');
+  print('');
+  final header = _padRight('ID', 20) +
+      _padRight('PORT', 8) +
+      _padRight('PID', 8) +
+      'PROJECT';
+  print(header);
+  print('-' * 60);
+  for (final e in entries) {
+    final alive = await ServerRegistry.isAlive(e.id);
+    final status = alive ? '' : ' (unreachable)';
+    print(_padRight(e.id, 20) +
+        _padRight(e.port.toString(), 8) +
+        _padRight(e.pid.toString(), 8) +
+        e.projectPath +
+        status);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// stop
+// ---------------------------------------------------------------------------
+
+Future<void> _cmdStop(List<String> args, OutputFormat format) async {
+  final id = _parseFlag(args, '--id');
+  if (id == null) {
+    print('Usage: flutter_skill server stop --id=<name>');
+    exit(1);
+  }
+
+  // Send a JSON-RPC shutdown request — or just unregister if unreachable.
+  bool sent = false;
+  try {
+    final client = SkillClient.byId(id);
+    await client.call('shutdown', {});
+    sent = true;
+  } catch (_) {
+    // Server may already be down — just clean the registry entry.
+  }
+
+  await ServerRegistry.unregister(id);
+
+  if (format == OutputFormat.json) {
+    print(jsonEncode({'id': id, 'stopped': true, 'signaled': sent}));
+  } else {
+    print(sent
+        ? 'Server "$id" stopped.'
+        : 'Server "$id" was not reachable; registry entry removed.');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+Future<void> _cmdStatus(List<String> args, OutputFormat format) async {
+  final id = _parseFlag(args, '--id');
+  if (id == null) {
+    print('Usage: flutter_skill server status --id=<name>');
+    exit(1);
+  }
+
+  final entry = await ServerRegistry.get(id);
+  if (entry == null) {
+    if (format == OutputFormat.json) {
+      print(jsonEncode({'id': id, 'found': false}));
+    } else {
+      print('No server registered with id "$id".');
+    }
+    return;
+  }
+
+  final alive = await ServerRegistry.isAlive(id);
+
+  if (format == OutputFormat.json) {
+    final data = entry.toJson();
+    data['alive'] = alive;
+    print(jsonEncode(data));
+    return;
+  }
+
+  print('Server: ${entry.id}');
+  print('  Status  : ${alive ? "running" : "unreachable"}');
+  print('  Port    : ${entry.port}');
+  print('  PID     : ${entry.pid}');
+  print('  Project : ${entry.projectPath}');
+  print('  Device  : ${entry.deviceId}');
+  print('  URI     : ${entry.vmServiceUri}');
+  print('  Started : ${entry.startedAt.toLocal()}');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+String? _parseFlag(List<String> args, String flag) {
+  for (final arg in args) {
+    if (arg.startsWith('$flag=')) return arg.substring(flag.length + 1);
+  }
+  return null;
+}
+
+String _padRight(String s, int width) => s.padRight(width);

--- a/lib/src/cli/server_cmd.dart
+++ b/lib/src/cli/server_cmd.dart
@@ -40,6 +40,7 @@ Future<void> runServerCmd(List<String> args) async {
 // ---------------------------------------------------------------------------
 
 Future<void> _cmdList(OutputFormat format) async {
+  await ServerRegistry.prune(); // Clean stale entries before listing.
   final entries = await ServerRegistry.listAll();
 
   if (format == OutputFormat.json) {

--- a/lib/src/cli/server_cmd.dart
+++ b/lib/src/cli/server_cmd.dart
@@ -13,7 +13,7 @@ import 'output_format.dart';
 ///   status --id=<name>          — show status of a named server
 Future<void> runServerCmd(List<String> args) async {
   final format = resolveOutputFormat(args);
-  final cleanArgs = stripOutputFlag(args);
+  final cleanArgs = stripOutputFormatFlag(args);
 
   final sub = cleanArgs.isNotEmpty ? cleanArgs[0] : 'list';
   final subArgs = cleanArgs.length > 1 ? cleanArgs.sublist(1) : <String>[];
@@ -55,18 +55,18 @@ Future<void> _cmdList(OutputFormat format) async {
   // Human-readable table.
   print('Running skill servers:');
   print('');
-  final header = _padRight('ID', 20) +
-      _padRight('PORT', 8) +
-      _padRight('PID', 8) +
+  final header = 'ID'.padRight(20) +
+      'PORT'.padRight(8) +
+      'PID'.padRight(8) +
       'PROJECT';
   print(header);
   print('-' * 60);
   for (final e in entries) {
     final alive = await ServerRegistry.isAlive(e.id);
     final status = alive ? '' : ' (unreachable)';
-    print(_padRight(e.id, 20) +
-        _padRight(e.port.toString(), 8) +
-        _padRight(e.pid.toString(), 8) +
+    print(e.id.padRight(20) +
+        e.port.toString().padRight(8) +
+        e.pid.toString().padRight(8) +
         e.projectPath +
         status);
   }
@@ -84,16 +84,17 @@ Future<void> _cmdStop(List<String> args, OutputFormat format) async {
   }
 
   // Send a JSON-RPC shutdown request — or just unregister if unreachable.
+  // When shutdown succeeds, the server process exits itself (and cleans its
+  // own registry entry). Only unregister manually in the catch path.
   bool sent = false;
   try {
     final client = SkillClient.byId(id);
     await client.call('shutdown', {});
     sent = true;
   } catch (_) {
-    // Server may already be down — just clean the registry entry.
+    // Server unreachable — clean the registry entry manually.
+    await ServerRegistry.unregister(id);
   }
-
-  await ServerRegistry.unregister(id);
 
   if (format == OutputFormat.json) {
     print(jsonEncode({'id': id, 'stopped': true, 'signaled': sent}));
@@ -154,5 +155,3 @@ String? _parseFlag(List<String> args, String flag) {
   }
   return null;
 }
-
-String _padRight(String s, int width) => s.padRight(width);

--- a/lib/src/drivers/flutter_driver.dart
+++ b/lib/src/drivers/flutter_driver.dart
@@ -559,21 +559,14 @@ Auto-setup: run  diagnose_project()  to fix automatically.
   }
 
   Future<void> hotRestart() async {
-    if (_service == null || _isolateId == null) {
-      throw Exception('Not connected');
-    }
-    try {
-      await _service!.reloadSources(_isolateId!);
-    } catch (e) {
-      if (!_isConnectionError(e)) rethrow;
-      if (await _reconnect()) {
-        await _service!.reloadSources(_isolateId!);
-        return;
-      }
-      throw Exception('❌ VM Service connection lost and reconnection failed.\n'
-          'URI: $wsUri\n'
-          'Original error: $e');
-    }
+    // The VM Service protocol does not expose a hot-restart RPC that can be
+    // called externally. A real hot restart requires re-running the Dart
+    // program from scratch, which is only possible by invoking `flutter run`
+    // again or using the Flutter tool's stdin protocol.
+    // Throw UnsupportedError so callers can detect this and fall back to
+    // hotReload or surface a warning to the user.
+    throw UnsupportedError('hotRestart is not supported via the VM Service. '
+        'Use hotReload for source updates, or restart the app via flutter run.');
   }
 
   Future<Map<String, dynamic>> getLayoutTree() async {

--- a/lib/src/server_registry.dart
+++ b/lib/src/server_registry.dart
@@ -74,8 +74,9 @@ class ServerRegistry {
         .writeAsString(jsonEncode(entry.toJson()), flush: true);
   }
 
-  /// Read a single server entry by ID. Returns null if not found.
+  /// Read a single server entry by ID. Returns null if not found or id is invalid.
   static Future<ServerEntry?> get(String id) async {
+    if (!RegExp(r'^[a-zA-Z0-9_\-]+$').hasMatch(id)) return null;
     final file = _entryFile(id);
     if (!await file.exists()) return null;
     try {
@@ -87,30 +88,42 @@ class ServerRegistry {
     }
   }
 
-  /// Return all registered entries, filtering out stale ones (PID no longer alive).
+  /// Return all registered entries. Does NOT delete stale entries.
+  /// Call [prune] separately to clean up stale entries.
   static Future<List<ServerEntry>> listAll() async {
     if (!await _registryDir.exists()) return [];
-
     final entries = <ServerEntry>[];
     await for (final entity in _registryDir.list()) {
-      if (entity is! File) continue;
-      if (!entity.path.endsWith('.json')) continue;
+      if (entity is! File || !entity.path.endsWith('.json')) continue;
       try {
         final json =
             jsonDecode(await entity.readAsString()) as Map<String, dynamic>;
-        final entry = ServerEntry.fromJson(json);
-        // Filter stale entries — check if the process is still alive.
-        if (await _isPidAlive(entry.pid)) {
-          entries.add(entry);
-        } else {
-          // Clean up stale entry silently.
-          await entity.delete().catchError((_) => entity);
-        }
+        entries.add(ServerEntry.fromJson(json));
       } catch (_) {
         // Skip malformed files.
       }
     }
     return entries;
+  }
+
+  /// Delete registry entries whose process is no longer alive.
+  static Future<void> prune() async {
+    if (!await _registryDir.exists()) return;
+    await for (final entity in _registryDir.list()) {
+      if (entity is! File || !entity.path.endsWith('.json')) continue;
+      try {
+        final json =
+            jsonDecode(await entity.readAsString()) as Map<String, dynamic>;
+        final entry = ServerEntry.fromJson(json);
+        if (!await _isPidAlive(entry.pid)) {
+          await entity.delete().catchError((_) => entity);
+          final sock = _sockFile(entry.id);
+          if (await sock.exists()) await sock.delete().catchError((_) => sock);
+        }
+      } catch (_) {
+        // Skip malformed files.
+      }
+    }
   }
 
   /// Delete a server entry (and its Unix socket file if present).
@@ -128,9 +141,10 @@ class ServerRegistry {
     return await _isTcpPortOpen('127.0.0.1', entry.port);
   }
 
-  /// Unix socket path for a server id, or null on Windows.
+  /// Unix socket path for a server id, or null on Windows or when id is invalid.
   static String? unixSocketPath(String id) {
     if (Platform.isWindows) return null;
+    if (!RegExp(r'^[a-zA-Z0-9_\-]+$').hasMatch(id)) return null;
     return _sockFile(id).path;
   }
 

--- a/lib/src/server_registry.dart
+++ b/lib/src/server_registry.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// A single named server instance entry stored in the registry.
+class ServerEntry {
+  final String id;
+  final int port;
+  final int pid;
+  final String projectPath;
+  final String deviceId;
+  final String vmServiceUri;
+  final DateTime startedAt;
+
+  const ServerEntry({
+    required this.id,
+    required this.port,
+    required this.pid,
+    required this.projectPath,
+    required this.deviceId,
+    required this.vmServiceUri,
+    required this.startedAt,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'port': port,
+        'pid': pid,
+        'projectPath': projectPath,
+        'deviceId': deviceId,
+        'vmServiceUri': vmServiceUri,
+        'startedAt': startedAt.toIso8601String(),
+      };
+
+  factory ServerEntry.fromJson(Map<String, dynamic> json) => ServerEntry(
+        id: json['id'] as String,
+        port: json['port'] as int,
+        pid: json['pid'] as int,
+        projectPath: json['projectPath'] as String? ?? '',
+        deviceId: json['deviceId'] as String? ?? '',
+        vmServiceUri: json['vmServiceUri'] as String? ?? '',
+        startedAt: json['startedAt'] != null
+            ? DateTime.parse(json['startedAt'] as String)
+            : DateTime.now(),
+      );
+}
+
+/// Manages ~/.flutter_skill/servers/ registry of named server instances.
+class ServerRegistry {
+  static Directory get _registryDir {
+    final home = Platform.environment['HOME'] ??
+        Platform.environment['USERPROFILE'] ??
+        '.';
+    final sep = Platform.pathSeparator;
+    return Directory('$home${sep}.flutter_skill${sep}servers');
+  }
+
+  static File _entryFile(String id) =>
+      File('${_registryDir.path}${Platform.pathSeparator}$id.json');
+
+  static File _sockFile(String id) =>
+      File('${_registryDir.path}${Platform.pathSeparator}$id.sock');
+
+  /// Write a server entry to disk.
+  static Future<void> register(ServerEntry entry) async {
+    await _registryDir.create(recursive: true);
+    await _entryFile(entry.id)
+        .writeAsString(jsonEncode(entry.toJson()), flush: true);
+  }
+
+  /// Read a single server entry by ID. Returns null if not found.
+  static Future<ServerEntry?> get(String id) async {
+    final file = _entryFile(id);
+    if (!await file.exists()) return null;
+    try {
+      final json =
+          jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+      return ServerEntry.fromJson(json);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Return all registered entries, filtering out stale ones (PID no longer alive).
+  static Future<List<ServerEntry>> listAll() async {
+    if (!await _registryDir.exists()) return [];
+
+    final entries = <ServerEntry>[];
+    await for (final entity in _registryDir.list()) {
+      if (entity is! File) continue;
+      if (!entity.path.endsWith('.json')) continue;
+      try {
+        final json =
+            jsonDecode(await entity.readAsString()) as Map<String, dynamic>;
+        final entry = ServerEntry.fromJson(json);
+        // Filter stale entries — check if the process is still alive.
+        if (await _isPidAlive(entry.pid)) {
+          entries.add(entry);
+        } else {
+          // Clean up stale entry silently.
+          await entity.delete().catchError((_) => entity);
+        }
+      } catch (_) {
+        // Skip malformed files.
+      }
+    }
+    return entries;
+  }
+
+  /// Delete a server entry (and its Unix socket file if present).
+  static Future<void> unregister(String id) async {
+    final file = _entryFile(id);
+    if (await file.exists()) await file.delete();
+    final sock = _sockFile(id);
+    if (await sock.exists()) await sock.delete();
+  }
+
+  /// Check whether the TCP port for the named server is accepting connections.
+  static Future<bool> isAlive(String id) async {
+    final entry = await get(id);
+    if (entry == null) return false;
+    return await _isTcpPortOpen('127.0.0.1', entry.port);
+  }
+
+  /// Unix socket path for a server id, or null on Windows.
+  static String? unixSocketPath(String id) {
+    if (Platform.isWindows) return null;
+    return _sockFile(id).path;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  static Future<bool> _isPidAlive(int pid) async {
+    try {
+      if (Platform.isWindows) {
+        final result = await Process.run(
+            'tasklist', ['/FI', 'PID eq $pid', '/NH'],
+            runInShell: true);
+        return result.stdout.toString().contains(pid.toString());
+      } else {
+        // kill -0 checks existence without sending a real signal.
+        final result =
+            await Process.run('kill', ['-0', pid.toString()], runInShell: true);
+        return result.exitCode == 0;
+      }
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static Future<bool> _isTcpPortOpen(String host, int port) async {
+    try {
+      final socket = await Socket.connect(host, port,
+          timeout: const Duration(milliseconds: 500));
+      await socket.close();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/src/server_registry.dart
+++ b/lib/src/server_registry.dart
@@ -61,7 +61,14 @@ class ServerRegistry {
       File('${_registryDir.path}${Platform.pathSeparator}$id.sock');
 
   /// Write a server entry to disk.
+  ///
+  /// Throws [ArgumentError] if the entry id contains characters that could
+  /// be used for path traversal attacks.
   static Future<void> register(ServerEntry entry) async {
+    if (!RegExp(r'^[a-zA-Z0-9_\-]+$').hasMatch(entry.id)) {
+      throw ArgumentError(
+          'Invalid server id "${entry.id}". Only letters, numbers, hyphens, and underscores are allowed.');
+    }
     await _registryDir.create(recursive: true);
     await _entryFile(entry.id)
         .writeAsString(jsonEncode(entry.toJson()), flush: true);
@@ -137,7 +144,13 @@ class ServerRegistry {
         final result = await Process.run(
             'tasklist', ['/FI', 'PID eq $pid', '/NH'],
             runInShell: true);
-        return result.stdout.toString().contains(pid.toString());
+        // Use word-boundary matching: PID column is space-padded in tasklist output.
+        // A simple contains() would match PID 123 inside 1234.
+        final output = result.stdout.toString();
+        return output.split('\n').any((line) {
+          final parts = line.trim().split(RegExp(r'\s+'));
+          return parts.isNotEmpty && parts.any((p) => p == pid.toString());
+        });
       } else {
         // kill -0 checks existence without sending a real signal.
         final result =

--- a/lib/src/server_registry.dart
+++ b/lib/src/server_registry.dart
@@ -64,11 +64,25 @@ class ServerRegistry {
   ///
   /// Throws [ArgumentError] if the entry id contains characters that could
   /// be used for path traversal attacks.
+  ///
+  /// Throws [StateError] if a server with the same id is already running
+  /// (i.e. its PID is still alive). Stop the existing server first with
+  /// `flutter_skill server stop --id=<id>` before registering a new one.
   static Future<void> register(ServerEntry entry) async {
     if (!RegExp(r'^[a-zA-Z0-9_\-]+$').hasMatch(entry.id)) {
       throw ArgumentError(
           'Invalid server id "${entry.id}". Only letters, numbers, hyphens, and underscores are allowed.');
     }
+
+    // Prevent silent overwrites: check whether a live server already owns
+    // this id before writing a new entry.
+    final existing = await get(entry.id);
+    if (existing != null && await _isPidAlive(existing.pid)) {
+      throw StateError(
+          'A server with id "${entry.id}" is already running on port ${existing.port} '
+          '(PID ${existing.pid}). Stop it first: flutter_skill server stop --id=${entry.id}');
+    }
+
     await _registryDir.create(recursive: true);
     await _entryFile(entry.id)
         .writeAsString(jsonEncode(entry.toJson()), flush: true);

--- a/lib/src/skill_client.dart
+++ b/lib/src/skill_client.dart
@@ -10,11 +10,14 @@ class SkillClient {
   final String? serverId;
   final int? directPort;
 
-  int _nextId = 1;
-
   SkillClient.byId(String id)
       : serverId = id,
-        directPort = null;
+        directPort = null {
+    if (!RegExp(r'^[a-zA-Z0-9_\-]+$').hasMatch(id)) {
+      throw ArgumentError(
+          'Invalid server id "$id". Only letters, numbers, hyphens, and underscores are allowed.');
+    }
+  }
 
   SkillClient.byPort(int port)
       : serverId = null,
@@ -25,7 +28,7 @@ class SkillClient {
   /// Throws if the server returns an error or the connection fails.
   Future<Map<String, dynamic>> call(
       String method, Map<String, dynamic> params) async {
-    final id = _nextId++;
+    const id = 1; // Each client instance makes one call; id is always 1.
 
     Socket socket;
     try {

--- a/lib/src/skill_client.dart
+++ b/lib/src/skill_client.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'server_registry.dart';
+
+/// Client that connects to a named [SkillServer] over TCP (or Unix socket on
+/// macOS/Linux) and sends JSON-RPC 2.0 requests.
+class SkillClient {
+  final String? serverId;
+  final int? directPort;
+
+  int _nextId = 1;
+
+  SkillClient.byId(String id)
+      : serverId = id,
+        directPort = null;
+
+  SkillClient.byPort(int port)
+      : serverId = null,
+        directPort = port;
+
+  /// Send a JSON-RPC 2.0 request and return the result map.
+  ///
+  /// Throws if the server returns an error or the connection fails.
+  Future<Map<String, dynamic>> call(
+      String method, Map<String, dynamic> params) async {
+    final id = _nextId++;
+
+    Socket socket;
+    try {
+      socket = await _connect();
+    } catch (e) {
+      throw Exception(
+          'Could not connect to server "${serverId ?? directPort}": $e');
+    }
+
+    try {
+      final request = jsonEncode({
+        'jsonrpc': '2.0',
+        'id': id,
+        'method': method,
+        'params': params,
+      });
+
+      socket.writeln(request);
+
+      // Read lines until we get the response for our request id.
+      final completer = Completer<Map<String, dynamic>>();
+
+      socket.cast<List<int>>().transform(utf8.decoder).transform(const LineSplitter()).listen(
+        (line) {
+          if (completer.isCompleted) return;
+          try {
+            final response = jsonDecode(line) as Map<String, dynamic>;
+            if (response['id'] == id) {
+              if (response.containsKey('error')) {
+                final err = response['error'] as Map<String, dynamic>;
+                completer.completeError(
+                    Exception(err['message'] ?? 'Unknown error'));
+              } else {
+                completer.complete(
+                    response['result'] as Map<String, dynamic>? ?? {});
+              }
+            }
+          } catch (_) {
+            // Ignore lines that are not valid JSON for our id.
+          }
+        },
+        onError: (Object e) {
+          if (!completer.isCompleted) completer.completeError(e);
+        },
+        onDone: () {
+          if (!completer.isCompleted) {
+            completer.completeError(
+                Exception('Connection closed before response received'));
+          }
+        },
+        cancelOnError: true,
+      );
+
+      return await completer.future.timeout(
+        const Duration(seconds: 30),
+        onTimeout: () =>
+            throw TimeoutException('Request timed out', const Duration(seconds: 30)),
+      );
+    } finally {
+      await socket.close().catchError((_) {});
+    }
+  }
+
+  Future<Socket> _connect() async {
+    // Prefer Unix socket on non-Windows when available.
+    if (!Platform.isWindows && serverId != null) {
+      final sockPath = ServerRegistry.unixSocketPath(serverId!);
+      if (sockPath != null && await File(sockPath).exists()) {
+        try {
+          return await Socket.connect(
+            InternetAddress(sockPath, type: InternetAddressType.unix),
+            0,
+            timeout: const Duration(milliseconds: 500),
+          );
+        } catch (_) {
+          // Fall through to TCP.
+        }
+      }
+    }
+
+    final port = await _resolvePort();
+    return Socket.connect('127.0.0.1', port,
+        timeout: const Duration(seconds: 5));
+  }
+
+  Future<int> _resolvePort() async {
+    if (directPort != null) return directPort!;
+    final entry = await ServerRegistry.get(serverId!);
+    if (entry == null) {
+      throw Exception('No server registered with id "$serverId". '
+          'Run: flutter_skill connect --id=$serverId --port=<port>');
+    }
+    return entry.port;
+  }
+}

--- a/lib/src/skill_client.dart
+++ b/lib/src/skill_client.dart
@@ -51,12 +51,18 @@ class SkillClient {
       // Read lines until we get the response for our request id.
       final completer = Completer<Map<String, dynamic>>();
 
-      socket.cast<List<int>>().transform(utf8.decoder).transform(const LineSplitter()).listen(
+      late StreamSubscription<String> subscription;
+      subscription = socket
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen(
         (line) {
           if (completer.isCompleted) return;
           try {
             final response = jsonDecode(line) as Map<String, dynamic>;
             if (response['id'] == id) {
+              subscription.cancel();
               if (response.containsKey('error')) {
                 final err = response['error'] as Map<String, dynamic>;
                 completer.completeError(

--- a/lib/src/skill_server.dart
+++ b/lib/src/skill_server.dart
@@ -112,20 +112,20 @@ class SkillServer {
       return;
     }
 
-    final id = request['id'];
+    final requestId = request['id'];
     final method = request['method'] as String?;
     final params = (request['params'] as Map<String, dynamic>?) ?? {};
 
     if (method == null) {
-      _sendError(socket, id, -32600, 'Invalid Request: missing method');
+      _sendError(socket, requestId, -32600, 'Invalid Request: missing method');
       return;
     }
 
     try {
       final result = await _dispatch(method, params);
-      _sendResult(socket, id, result);
+      _sendResult(socket, requestId, result);
     } catch (e) {
-      _sendError(socket, id, -32000, e.toString());
+      _sendError(socket, requestId, -32000, e.toString());
     }
   }
 
@@ -175,6 +175,10 @@ class SkillServer {
           quality: (params['quality'] as num?)?.toDouble() ?? 1.0,
           maxWidth: params['maxWidth'] as int?,
         );
+        if (image == null) {
+          throw Exception(
+              'Screenshot returned null — app may not be visible');
+        }
         return {'image': image};
 
       case 'get_logs':
@@ -190,9 +194,26 @@ class SkillServer {
         return {'success': true};
 
       case 'hot_restart':
-        // AppDriver does not have a dedicated hotRestart; use hotReload as fallback.
+        if (driver is FlutterSkillClient) {
+          // Check if hotRestart is available; if not, fall back to hotReload with a warning.
+          try {
+            await (driver as FlutterSkillClient).hotRestart();
+            return {'success': true};
+          } catch (_) {
+            await driver.hotReload();
+            return {
+              'success': true,
+              'warning':
+                  'hotRestart not available; performed hotReload instead'
+            };
+          }
+        }
         await driver.hotReload();
-        return {'success': true};
+        return {
+          'success': true,
+          'warning':
+              'hotRestart not supported by this driver; performed hotReload'
+        };
 
       case 'scroll_to':
         final success = await driver.swipe(
@@ -201,6 +222,104 @@ class SkillServer {
           key: params['key'] as String?,
         );
         return {'success': success};
+
+      case 'assert_visible':
+        // Check if element is present in interactive elements list.
+        final assertVisibleKey =
+            params['key'] as String? ?? params['text'] as String?;
+        final assertVisibleElements =
+            await driver.getInteractiveElements(includePositions: false);
+        final assertVisibleFound = assertVisibleElements.any((e) {
+          if (e is! Map) return false;
+          return e['key'] == assertVisibleKey ||
+              e['text'] == assertVisibleKey ||
+              e['ref'] == assertVisibleKey;
+        });
+        if (!assertVisibleFound) {
+          throw Exception('Element not found: $assertVisibleKey');
+        }
+        return {'success': true, 'visible': true};
+
+      case 'assert_gone':
+        final assertGoneKey =
+            params['key'] as String? ?? params['text'] as String?;
+        final assertGoneElements =
+            await driver.getInteractiveElements(includePositions: false);
+        final assertGoneFound = assertGoneElements.any((e) {
+          if (e is! Map) return false;
+          return e['key'] == assertGoneKey ||
+              e['text'] == assertGoneKey ||
+              e['ref'] == assertGoneKey;
+        });
+        if (assertGoneFound) {
+          throw Exception('Element still present: $assertGoneKey');
+        }
+        return {'success': true, 'gone': true};
+
+      case 'wait_for_element':
+        final waitKey =
+            params['key'] as String? ?? params['text'] as String?;
+        final timeoutMs = (params['timeout'] as num?)?.toInt() ?? 5000;
+        final deadline =
+            DateTime.now().add(Duration(milliseconds: timeoutMs));
+        while (DateTime.now().isBefore(deadline)) {
+          final waitElements =
+              await driver.getInteractiveElements(includePositions: false);
+          final waitFound = waitElements.any((e) {
+            if (e is! Map) return false;
+            return e['key'] == waitKey ||
+                e['text'] == waitKey ||
+                e['ref'] == waitKey;
+          });
+          if (waitFound) return {'success': true};
+          await Future<void>.delayed(const Duration(milliseconds: 200));
+        }
+        throw Exception('Timeout waiting for element: $waitKey');
+
+      case 'get_text':
+        // Get visible text of a specific element or entire screen.
+        final getTextKey = params['key'] as String?;
+        if (getTextKey == null) {
+          final getTextElements =
+              await driver.getInteractiveElements(includePositions: false);
+          final texts = getTextElements
+              .whereType<Map>()
+              .map((e) => e['text']?.toString() ?? '')
+              .where((t) => t.isNotEmpty)
+              .toList();
+          return {'texts': texts};
+        }
+        final getTextAllElements =
+            await driver.getInteractiveElements(includePositions: false);
+        final getTextEl = getTextAllElements.whereType<Map>().firstWhere(
+              (e) => e['key'] == getTextKey || e['ref'] == getTextKey,
+              orElse: () => {},
+            );
+        return {'text': getTextEl['text']?.toString() ?? ''};
+
+      case 'find_element':
+        final findKey =
+            params['key'] as String? ?? params['text'] as String?;
+        final findElements =
+            await driver.getInteractiveElements(includePositions: true);
+        final findEl = findElements.whereType<Map>().firstWhere(
+              (e) =>
+                  e['key'] == findKey ||
+                  e['text'] == findKey ||
+                  e['ref'] == findKey,
+              orElse: () => {},
+            );
+        if (findEl.isEmpty) throw Exception('Element not found: $findKey');
+        return Map<String, dynamic>.from(findEl);
+
+      case 'go_back':
+        try {
+          final d = driver as FlutterSkillClient;
+          await d.goBack();
+        } catch (_) {
+          // Driver doesn't support goBack — no-op (web navigation not available).
+        }
+        return {'success': true};
 
       case 'shutdown':
         // Schedule stop after the response is sent so the client gets a reply.

--- a/lib/src/skill_server.dart
+++ b/lib/src/skill_server.dart
@@ -24,6 +24,13 @@ class SkillServer {
   int? _port;
   final List<Socket> _connections = [];
 
+  final _shutdownController = StreamController<void>.broadcast();
+
+  /// Stream that emits when the server has been asked to shut down via the
+  /// `shutdown` JSON-RPC method. Callers (e.g. [runConnect]) can listen to
+  /// this stream to perform orderly cleanup.
+  Stream<void> get onShutdownRequested => _shutdownController.stream;
+
   SkillServer({
     required this.id,
     required this.driver,
@@ -79,6 +86,9 @@ class SkillServer {
     await _tcpServer?.close();
     await _unixServer?.close();
     await ServerRegistry.unregister(id);
+    if (!_shutdownController.isClosed) {
+      await _shutdownController.close();
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -195,16 +205,16 @@ class SkillServer {
 
       case 'hot_restart':
         if (driver is FlutterSkillClient) {
-          // Check if hotRestart is available; if not, fall back to hotReload with a warning.
           try {
             await (driver as FlutterSkillClient).hotRestart();
             return {'success': true};
-          } catch (_) {
+          } catch (e) {
+            // hotRestart failed — fall back to hotReload with warning.
             await driver.hotReload();
             return {
               'success': true,
               'warning':
-                  'hotRestart not available; performed hotReload instead'
+                  'hotRestart failed ($e); performed hotReload instead',
             };
           }
         }
@@ -212,16 +222,25 @@ class SkillServer {
         return {
           'success': true,
           'warning':
-              'hotRestart not supported by this driver; performed hotReload'
+              'hotRestart not supported by this driver; performed hotReload',
         };
 
       case 'scroll_to':
-        final success = await driver.swipe(
-          direction: params['direction'] as String? ?? 'down',
-          distance: (params['distance'] as num?)?.toDouble() ?? 300,
-          key: params['key'] as String?,
-        );
-        return {'success': success};
+        final scrollKey = params['key'] as String?;
+        final scrollText = params['text'] as String?;
+        try {
+          // FlutterSkillClient has scrollTo; other drivers fall back to swipe.
+          final fsc = driver as FlutterSkillClient;
+          final result = await fsc.scrollTo(key: scrollKey, text: scrollText);
+          return result;
+        } catch (_) {
+          final success = await driver.swipe(
+            direction: params['direction'] as String? ?? 'down',
+            distance: (params['distance'] as num?)?.toDouble() ?? 300,
+            key: scrollKey,
+          );
+          return {'success': success};
+        }
 
       case 'assert_visible':
         // Check if element is present in interactive elements list.
@@ -229,12 +248,8 @@ class SkillServer {
             params['key'] as String? ?? params['text'] as String?;
         final assertVisibleElements =
             await driver.getInteractiveElements(includePositions: false);
-        final assertVisibleFound = assertVisibleElements.any((e) {
-          if (e is! Map) return false;
-          return e['key'] == assertVisibleKey ||
-              e['text'] == assertVisibleKey ||
-              e['ref'] == assertVisibleKey;
-        });
+        final assertVisibleFound =
+            assertVisibleElements.any((e) => _elementMatches(e, assertVisibleKey));
         if (!assertVisibleFound) {
           throw Exception('Element not found: $assertVisibleKey');
         }
@@ -245,12 +260,8 @@ class SkillServer {
             params['key'] as String? ?? params['text'] as String?;
         final assertGoneElements =
             await driver.getInteractiveElements(includePositions: false);
-        final assertGoneFound = assertGoneElements.any((e) {
-          if (e is! Map) return false;
-          return e['key'] == assertGoneKey ||
-              e['text'] == assertGoneKey ||
-              e['ref'] == assertGoneKey;
-        });
+        final assertGoneFound =
+            assertGoneElements.any((e) => _elementMatches(e, assertGoneKey));
         if (assertGoneFound) {
           throw Exception('Element still present: $assertGoneKey');
         }
@@ -265,13 +276,9 @@ class SkillServer {
         while (DateTime.now().isBefore(deadline)) {
           final waitElements =
               await driver.getInteractiveElements(includePositions: false);
-          final waitFound = waitElements.any((e) {
-            if (e is! Map) return false;
-            return e['key'] == waitKey ||
-                e['text'] == waitKey ||
-                e['ref'] == waitKey;
-          });
-          if (waitFound) return {'success': true};
+          if (waitElements.any((e) => _elementMatches(e, waitKey))) {
+            return {'success': true};
+          }
           await Future<void>.delayed(const Duration(milliseconds: 200));
         }
         throw Exception('Timeout waiting for element: $waitKey');
@@ -292,7 +299,7 @@ class SkillServer {
         final getTextAllElements =
             await driver.getInteractiveElements(includePositions: false);
         final getTextEl = getTextAllElements.whereType<Map>().firstWhere(
-              (e) => e['key'] == getTextKey || e['ref'] == getTextKey,
+              (e) => _elementMatches(e, getTextKey),
               orElse: () => {},
             );
         return {'text': getTextEl['text']?.toString() ?? ''};
@@ -303,10 +310,7 @@ class SkillServer {
         final findElements =
             await driver.getInteractiveElements(includePositions: true);
         final findEl = findElements.whereType<Map>().firstWhere(
-              (e) =>
-                  e['key'] == findKey ||
-                  e['text'] == findKey ||
-                  e['ref'] == findKey,
+              (e) => _elementMatches(e, findKey),
               orElse: () => {},
             );
         if (findEl.isEmpty) throw Exception('Element not found: $findKey');
@@ -322,11 +326,9 @@ class SkillServer {
         return {'success': true};
 
       case 'shutdown':
-        // Schedule stop after the response is sent so the client gets a reply.
-        Future.microtask(() async {
-          await stop();
-          exit(0);
-        });
+        // Signal listeners (e.g. runConnect) to perform orderly shutdown after
+        // the response is delivered to the client.
+        Future.microtask(() => _shutdownController.add(null));
         return {'success': true};
 
       case 'ping':
@@ -341,22 +343,32 @@ class SkillServer {
   // JSON-RPC helpers
   // ---------------------------------------------------------------------------
 
-  void _sendResult(Socket socket, dynamic id, Map<String, dynamic> result) {
+  void _sendResult(Socket socket, dynamic requestId, Map<String, dynamic> result) {
     final response = jsonEncode({
       'jsonrpc': '2.0',
-      'id': id,
+      'id': requestId,
       'result': result,
     });
-    socket.writeln(response);
+    try {
+      socket.writeln(response);
+    } catch (_) {
+      _connections.remove(socket);
+      socket.destroy();
+    }
   }
 
-  void _sendError(Socket socket, dynamic id, int code, String message) {
+  void _sendError(Socket socket, dynamic requestId, int code, String message) {
     final response = jsonEncode({
       'jsonrpc': '2.0',
-      'id': id,
+      'id': requestId,
       'error': {'code': code, 'message': message},
     });
-    socket.writeln(response);
+    try {
+      socket.writeln(response);
+    } catch (_) {
+      _connections.remove(socket);
+      socket.destroy();
+    }
   }
 
   String _vmServiceUri() {
@@ -364,5 +376,15 @@ class SkillServer {
       return (driver as FlutterSkillClient).vmServiceUri;
     }
     return '';
+  }
+
+  // ---------------------------------------------------------------------------
+  // Element matching helper
+  // ---------------------------------------------------------------------------
+
+  /// Returns true if [e] is a Map that matches [query] by key, text, or ref.
+  static bool _elementMatches(dynamic e, String? query) {
+    if (e is! Map || query == null) return false;
+    return e['key'] == query || e['text'] == query || e['ref'] == query;
   }
 }

--- a/lib/src/skill_server.dart
+++ b/lib/src/skill_server.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'drivers/app_driver.dart';
+import 'drivers/flutter_driver.dart';
 import 'server_registry.dart';
 
 /// A lightweight JSON-RPC 2.0 server over raw TCP (newline-delimited JSON)
@@ -130,6 +131,10 @@ class SkillServer {
 
   // ---------------------------------------------------------------------------
   // Method dispatch — mirrors the MCP tool set
+  //
+  // Phase 1 implemented methods:
+  //   tap, enter_text, swipe, inspect, screenshot, get_logs, clear_logs,
+  //   hot_reload, hot_restart, scroll_to, ping, shutdown
   // ---------------------------------------------------------------------------
 
   Future<Map<String, dynamic>> _dispatch(
@@ -184,6 +189,27 @@ class SkillServer {
         await driver.hotReload();
         return {'success': true};
 
+      case 'hot_restart':
+        // AppDriver does not have a dedicated hotRestart; use hotReload as fallback.
+        await driver.hotReload();
+        return {'success': true};
+
+      case 'scroll_to':
+        final success = await driver.swipe(
+          direction: params['direction'] as String? ?? 'down',
+          distance: (params['distance'] as num?)?.toDouble() ?? 300,
+          key: params['key'] as String?,
+        );
+        return {'success': success};
+
+      case 'shutdown':
+        // Schedule stop after the response is sent so the client gets a reply.
+        Future.microtask(() async {
+          await stop();
+          exit(0);
+        });
+        return {'success': true};
+
       case 'ping':
         return {'pong': true, 'server': id};
 
@@ -215,21 +241,9 @@ class SkillServer {
   }
 
   String _vmServiceUri() {
-    // If the driver is a FlutterSkillClient it exposes vmServiceUri.
-    try {
-      // Use reflection-free duck typing via dynamic dispatch.
-      final d = driver as dynamic;
-      return (d.vmServiceUri as String?) ?? '';
-    } catch (_) {
-      return '';
+    if (driver is FlutterSkillClient) {
+      return (driver as FlutterSkillClient).vmServiceUri;
     }
+    return '';
   }
-}
-
-/// Find a random free TCP port by binding temporarily.
-Future<int> findFreePort() async {
-  final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-  final port = socket.port;
-  await socket.close();
-  return port;
 }

--- a/lib/src/skill_server.dart
+++ b/lib/src/skill_server.dart
@@ -23,6 +23,7 @@ class SkillServer {
   ServerSocket? _unixServer;
   int? _port;
   final List<Socket> _connections = [];
+  bool _stopped = false;
 
   final _shutdownController = StreamController<void>.broadcast();
 
@@ -79,8 +80,10 @@ class SkillServer {
 
   /// Stop the server and unregister from the registry.
   Future<void> stop() async {
+    if (_stopped) return;
+    _stopped = true;
     for (final conn in List<Socket>.from(_connections)) {
-      await conn.close().catchError((_) => conn);
+      await conn.close().catchError((_) {});
     }
     _connections.clear();
     await _tcpServer?.close();
@@ -235,8 +238,8 @@ class SkillServer {
           return result;
         } catch (_) {
           final success = await driver.swipe(
-            direction: params['direction'] as String? ?? 'down',
-            distance: (params['distance'] as num?)?.toDouble() ?? 300,
+            direction: 'down',
+            distance: 300,
             key: scrollKey,
           );
           return {'success': success};

--- a/lib/src/skill_server.dart
+++ b/lib/src/skill_server.dart
@@ -1,0 +1,235 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'drivers/app_driver.dart';
+import 'server_registry.dart';
+
+/// A lightweight JSON-RPC 2.0 server over raw TCP (newline-delimited JSON)
+/// that exposes AppDriver capabilities to local CLI clients.
+///
+/// Lifecycle:
+///   1. Call [start] — binds a random free TCP port, registers in [ServerRegistry].
+///   2. Clients connect and send newline-delimited JSON-RPC 2.0 requests.
+///   3. Call [stop] — closes all connections, unregisters from [ServerRegistry].
+class SkillServer {
+  final String id;
+  final AppDriver driver;
+  final String projectPath;
+  final String deviceId;
+
+  ServerSocket? _tcpServer;
+  ServerSocket? _unixServer;
+  int? _port;
+  final List<Socket> _connections = [];
+
+  SkillServer({
+    required this.id,
+    required this.driver,
+    this.projectPath = '',
+    this.deviceId = '',
+  });
+
+  int get port => _port ?? 0;
+
+  /// Start listening. Binds a random free TCP port and registers in the registry.
+  Future<void> start() async {
+    _tcpServer = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    _port = _tcpServer!.port;
+
+    _tcpServer!.listen(_handleConnection);
+
+    // On Unix, also bind a Unix domain socket for lower-latency local IPC.
+    final sockPath = ServerRegistry.unixSocketPath(id);
+    if (sockPath != null) {
+      try {
+        // Remove stale socket file if present.
+        final sockFile = File(sockPath);
+        if (await sockFile.exists()) await sockFile.delete();
+
+        _unixServer = await ServerSocket.bind(
+          InternetAddress(sockPath, type: InternetAddressType.unix),
+          0,
+        );
+        _unixServer!.listen(_handleConnection);
+      } catch (_) {
+        // Unix socket is optional — silently ignore failures.
+      }
+    }
+
+    final entry = ServerEntry(
+      id: id,
+      port: _port!,
+      pid: pid,
+      projectPath: projectPath,
+      deviceId: deviceId,
+      vmServiceUri: _vmServiceUri(),
+      startedAt: DateTime.now(),
+    );
+    await ServerRegistry.register(entry);
+  }
+
+  /// Stop the server and unregister from the registry.
+  Future<void> stop() async {
+    for (final conn in List<Socket>.from(_connections)) {
+      await conn.close().catchError((_) => conn);
+    }
+    _connections.clear();
+    await _tcpServer?.close();
+    await _unixServer?.close();
+    await ServerRegistry.unregister(id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connection handling
+  // ---------------------------------------------------------------------------
+
+  void _handleConnection(Socket socket) {
+    _connections.add(socket);
+
+    socket
+        .cast<List<int>>()
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(
+          (line) => _handleLine(socket, line),
+          onDone: () => _connections.remove(socket),
+          onError: (_) => _connections.remove(socket),
+          cancelOnError: false,
+        );
+  }
+
+  Future<void> _handleLine(Socket socket, String line) async {
+    final trimmed = line.trim();
+    if (trimmed.isEmpty) return;
+
+    Map<String, dynamic> request;
+    try {
+      request = jsonDecode(trimmed) as Map<String, dynamic>;
+    } catch (e) {
+      _sendError(socket, null, -32700, 'Parse error: $e');
+      return;
+    }
+
+    final id = request['id'];
+    final method = request['method'] as String?;
+    final params = (request['params'] as Map<String, dynamic>?) ?? {};
+
+    if (method == null) {
+      _sendError(socket, id, -32600, 'Invalid Request: missing method');
+      return;
+    }
+
+    try {
+      final result = await _dispatch(method, params);
+      _sendResult(socket, id, result);
+    } catch (e) {
+      _sendError(socket, id, -32000, e.toString());
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Method dispatch — mirrors the MCP tool set
+  // ---------------------------------------------------------------------------
+
+  Future<Map<String, dynamic>> _dispatch(
+      String method, Map<String, dynamic> params) async {
+    switch (method) {
+      case 'tap':
+        final result = await driver.tap(
+          key: params['key'] as String?,
+          text: params['text'] as String?,
+          ref: params['ref'] as String?,
+        );
+        return result;
+
+      case 'enter_text':
+        final result = await driver.enterText(
+          params['key'] as String?,
+          params['text'] as String? ?? '',
+          ref: params['ref'] as String?,
+        );
+        return result;
+
+      case 'swipe':
+        final success = await driver.swipe(
+          direction: params['direction'] as String? ?? 'up',
+          distance: (params['distance'] as num?)?.toDouble() ?? 300,
+          key: params['key'] as String?,
+        );
+        return {'success': success};
+
+      case 'inspect':
+        final elements = await driver.getInteractiveElements(
+          includePositions: (params['includePositions'] as bool?) ?? true,
+        );
+        return {'elements': elements};
+
+      case 'screenshot':
+        final image = await driver.takeScreenshot(
+          quality: (params['quality'] as num?)?.toDouble() ?? 1.0,
+          maxWidth: params['maxWidth'] as int?,
+        );
+        return {'image': image};
+
+      case 'get_logs':
+        final logs = await driver.getLogs();
+        return {'logs': logs};
+
+      case 'clear_logs':
+        await driver.clearLogs();
+        return {'success': true};
+
+      case 'hot_reload':
+        await driver.hotReload();
+        return {'success': true};
+
+      case 'ping':
+        return {'pong': true, 'server': id};
+
+      default:
+        throw Exception('Method not found: $method');
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // JSON-RPC helpers
+  // ---------------------------------------------------------------------------
+
+  void _sendResult(Socket socket, dynamic id, Map<String, dynamic> result) {
+    final response = jsonEncode({
+      'jsonrpc': '2.0',
+      'id': id,
+      'result': result,
+    });
+    socket.writeln(response);
+  }
+
+  void _sendError(Socket socket, dynamic id, int code, String message) {
+    final response = jsonEncode({
+      'jsonrpc': '2.0',
+      'id': id,
+      'error': {'code': code, 'message': message},
+    });
+    socket.writeln(response);
+  }
+
+  String _vmServiceUri() {
+    // If the driver is a FlutterSkillClient it exposes vmServiceUri.
+    try {
+      // Use reflection-free duck typing via dynamic dispatch.
+      final d = driver as dynamic;
+      return (d.vmServiceUri as String?) ?? '';
+    } catch (_) {
+      return '';
+    }
+  }
+}
+
+/// Find a random free TCP port by binding temporarily.
+Future<int> findFreePort() async {
+  final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final port = socket.port;
+  await socket.close();
+  return port;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -215,10 +215,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -380,26 +380,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.28.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.16"
   typed_data:
     dependency: transitive
     description:

--- a/test/server_registry_test.dart
+++ b/test/server_registry_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:flutter_skill/src/server_registry.dart';
+
+void main() {
+  group('ServerRegistry', () {
+    ServerEntry _makeEntry(String id, {int port = 9999}) => ServerEntry(
+          id: id,
+          port: port,
+          pid: pid, // current process — guaranteed alive
+          projectPath: '/tmp/test',
+          deviceId: 'test-device',
+          vmServiceUri: 'ws://127.0.0.1:$port/ws',
+          startedAt: DateTime.now(),
+        );
+
+    test('register writes JSON file and get returns it', () async {
+      final entry = _makeEntry('test-server-reg-${pid}');
+      await ServerRegistry.register(entry);
+      final loaded = await ServerRegistry.get(entry.id);
+      expect(loaded, isNotNull);
+      expect(loaded!.id, equals(entry.id));
+      expect(loaded.port, equals(9999));
+      // Cleanup
+      await ServerRegistry.unregister(entry.id);
+    });
+
+    test('register rejects invalid id', () async {
+      final entry = _makeEntry('invalid/id');
+      expect(() => ServerRegistry.register(entry), throwsArgumentError);
+    });
+
+    test('register rejects path traversal id', () async {
+      final entry = _makeEntry('../evil');
+      expect(() => ServerRegistry.register(entry), throwsArgumentError);
+    });
+
+    test('get returns null for unknown id', () async {
+      final result = await ServerRegistry.get('nonexistent-server-xyz');
+      expect(result, isNull);
+    });
+
+    test('get returns null for invalid id', () async {
+      final result = await ServerRegistry.get('../evil');
+      expect(result, isNull);
+    });
+
+    test('unregister deletes entry', () async {
+      final id = 'to-delete-${pid}';
+      final entry = _makeEntry(id);
+      await ServerRegistry.register(entry);
+      expect(await ServerRegistry.get(id), isNotNull);
+      await ServerRegistry.unregister(id);
+      expect(await ServerRegistry.get(id), isNull);
+    });
+
+    test('listAll returns all registered entries', () async {
+      final idA = 'server-a-${pid}';
+      final idB = 'server-b-${pid}';
+      await ServerRegistry.register(_makeEntry(idA, port: 9991));
+      await ServerRegistry.register(_makeEntry(idB, port: 9992));
+      final all = await ServerRegistry.listAll();
+      expect(all.map((e) => e.id), containsAll([idA, idB]));
+      // Cleanup
+      await ServerRegistry.unregister(idA);
+      await ServerRegistry.unregister(idB);
+    });
+
+    test('register throws on collision with live server', () async {
+      final id = 'collision-test-${pid}';
+      final entry = _makeEntry(id);
+      await ServerRegistry.register(entry);
+      // Registering same id again with live pid should throw StateError.
+      expect(() => ServerRegistry.register(entry), throwsStateError);
+      // Cleanup
+      await ServerRegistry.unregister(id);
+    });
+  });
+}

--- a/test/skill_server_client_test.dart
+++ b/test/skill_server_client_test.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+import 'package:test/test.dart';
+import 'package:flutter_skill/src/skill_server.dart';
+import 'package:flutter_skill/src/skill_client.dart';
+import 'package:flutter_skill/src/server_registry.dart';
+import 'package:flutter_skill/src/drivers/app_driver.dart';
+
+/// Minimal mock driver for testing.
+class _MockDriver implements AppDriver {
+  @override
+  String get frameworkName => 'mock';
+
+  @override
+  bool get isConnected => true;
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<Map<String, dynamic>> tap(
+      {String? key, String? text, String? ref}) async =>
+      {'success': true, 'tapped': key ?? text};
+
+  @override
+  Future<Map<String, dynamic>> enterText(String? key, String text,
+      {String? ref}) async =>
+      {'success': true};
+
+  @override
+  Future<bool> swipe(
+      {required String direction,
+      double distance = 300,
+      String? key}) async =>
+      true;
+
+  @override
+  Future<List<dynamic>> getInteractiveElements(
+      {bool includePositions = true}) async =>
+      [];
+
+  @override
+  Future<Map<String, dynamic>> getInteractiveElementsStructured() async => {};
+
+  @override
+  Future<String?> takeScreenshot({double quality = 1.0, int? maxWidth}) async =>
+      null;
+
+  @override
+  Future<List<String>> getLogs() async => [];
+
+  @override
+  Future<void> clearLogs() async {}
+
+  @override
+  Future<void> hotReload() async {}
+}
+
+void main() {
+  group('SkillServer + SkillClient', () {
+    late SkillServer server;
+
+    setUp(() async {
+      final driver = _MockDriver();
+      server = SkillServer(
+        id: 'test-server-${DateTime.now().millisecondsSinceEpoch}',
+        driver: driver,
+      );
+      await server.start();
+    });
+
+    tearDown(() async {
+      await server.stop();
+      await ServerRegistry.unregister(server.id).catchError((_) {});
+    });
+
+    test('ping returns pong', () async {
+      final client = SkillClient.byPort(server.port);
+      final result = await client.call('ping', {});
+      expect(result['pong'], isTrue);
+    });
+
+    test('inspect returns elements list', () async {
+      final client = SkillClient.byPort(server.port);
+      final result = await client.call('inspect', {});
+      expect(result['elements'], isList);
+    });
+
+    test('tap returns success', () async {
+      final client = SkillClient.byPort(server.port);
+      final result = await client.call('tap', {'key': 'loginBtn'});
+      expect(result['success'], isTrue);
+    });
+
+    test('unknown method returns error', () async {
+      final client = SkillClient.byPort(server.port);
+      expect(
+        () => client.call('nonexistent_method', {}),
+        throwsException,
+      );
+    });
+
+    test('shutdown completes onShutdownRequested stream', () async {
+      final shutdownFired = Completer<void>();
+      server.onShutdownRequested.listen((_) {
+        if (!shutdownFired.isCompleted) shutdownFired.complete();
+      });
+      final client = SkillClient.byPort(server.port);
+      await client.call('shutdown', {});
+      await shutdownFired.future.timeout(const Duration(seconds: 2));
+      expect(shutdownFired.isCompleted, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Idea

This PR introduces a **named server registry** to `flutter_skill`, drawing inspiration from how the [Playwright CLI](https://playwright.dev/docs/cli) handles browser server instances — where you can start a server independently and then target it by name/endpoint from any command or test. The same pattern is applied here: instead of each command needing to discover and connect to a Flutter VM Service URI on its own, you attach once (`flutter_skill connect`), give the session a name, and every subsequent command just passes `--server=<name>`.

This makes `flutter_skill` feel more like a proper CLI tool for automation pipelines: stateless commands, named sessions, parallel execution across multiple apps.

## Changes

Adds a **named server registry + TCP IPC layer** so every MCP action can also be invoked as a plain CLI command targeting a named, running server instance.

### New commands

- `flutter_skill connect --id=myapp --port=50000` — attach to a running Flutter app and give it a persistent name
- `flutter_skill server list` — table of all running named servers
- `flutter_skill server stop --id=myapp` — stop a named server
- `flutter_skill server status --id=myapp` — show port, PID, project path, VM URI
- `flutter_skill servers` — shorthand for `server list`
- `flutter_skill ping --server=myapp` — health check a named server
- `flutter_skill tap "Login" --server=myapp` — run any action via a named server
- `flutter_skill screenshot --server=app-a,app-b` — parallel execution across multiple servers

### Architecture

| File | Role |
|---|---|
| `lib/src/server_registry.dart` | Reads/writes `~/.flutter_skill/servers/<id>.json`; PID-alive filtering, collision guard, path-traversal validation |
| `lib/src/skill_server.dart` | JSON-RPC 2.0 server over TCP (+ Unix socket fast-path on macOS/Linux) |
| `lib/src/skill_client.dart` | Resolves named server → port, sends JSON-RPC requests |
| `lib/src/cli/connect.dart` | `flutter_skill connect` command |
| `lib/src/cli/server_cmd.dart` | `flutter_skill server list/stop/status` |
| `lib/src/cli/ping_cmd.dart` | `flutter_skill ping` command |
| `lib/src/cli/output_format.dart` | `isCiEnvironment()` helper; `--output=json\|human` flag; `callServersParallel()` |

### Modified files (additive only — no breaking changes)

- **`lib/src/cli/launch.dart`** — new `--id=<name>` and `--detach` flags; auto-registers a SkillServer when the VM URI is discovered
- **`lib/src/cli/inspect.dart`** — new `--server=<id>[,...]` flag for parallel forwarding; `--output` flag
- **`lib/src/cli/act.dart`** — same `--server` pattern for all act subcommands
- **`bin/flutter_skill.dart`** — routes new commands while keeping `server` alone as the MCP server

### CI output

When `CI`, `GITHUB_ACTIONS`, `CIRCLECI`, `TRAVIS`, or `BUILDKITE` env vars are set, output defaults to JSON. Always overridable with `--output=json` or `--output=human`.

## Reference

The full development history, code review rounds, and discussion are in vinifig/flutter-skill-cli#1.

## Test plan

- [ ] `flutter_skill connect --id=myapp --port=50000` registers entry in `~/.flutter_skill/servers/myapp.json`
- [ ] `flutter_skill server list` shows the registered server
- [ ] `flutter_skill tap "Submit" --server=myapp` forwards tap to the named server
- [ ] `flutter_skill screenshot --server=a,b` runs in parallel and writes `screenshot_a.png` / `screenshot_b.png`
- [ ] `flutter_skill server stop --id=myapp` removes the registry entry and stops the server process
- [ ] `flutter_skill ping --server=myapp` exits 0 when reachable, 1 when not
- [ ] All existing commands (`launch`, `inspect`, `act` without `--server`) behave identically to before
- [ ] Unit tests pass: `dart test test/server_registry_test.dart test/skill_server_client_test.dart`