### PR TITLE
fix: resolve MCP server startup crash on macOS (issue #46)

### DIFF
--- a/packaging/npm/bin/cli.js
+++ b/packaging/npm/bin/cli.js
@@ -84,7 +84,7 @@ async function main() {
   const localBinaryPath = getLocalBinaryPath();
 
   // Try to use existing native binary
-  if (localBinaryPath && fs.existsSync(localBinaryPath)) {
+  if (localBinaryPath && fs.existsSync(localBinaryPath) && fs.statSync(localBinaryPath).size > 0) {
     // Always ensure the execute bit is set before spawning.
     // postinstall chmodSync can silently fail on some npm configurations
     // (e.g. restricted sandbox, npm run as root on certain macOS setups),

--- a/packaging/npm/dart/bin/server.dart
+++ b/packaging/npm/dart/bin/server.dart
@@ -1,3 +1,3 @@
-import 'package:flutter_skill/src/cli/server.dart';
+import 'package:flutter_skill_npm/src/cli/server.dart';
 
 void main(List<String> args) => runServer(args);


### PR DESCRIPTION
## Summary

Fixes #46 — MCP server fails to start on macOS v0.9.36.

Two root causes identified and fixed (as described in [this comment](https://github.com/ai-dashboad/flutter-skill/issues/46#issuecomment-4518842771)):

- **`spawn ENOEXEC` from zero-byte cached binary** — `packaging/npm/bin/cli.js` only checked if the binary file existed, not whether it had content. A failed/interrupted download leaves a 0-byte file that passes the existence check but crashes on execution. Added `fs.statSync(localBinaryPath).size > 0` to the guard.
- **Dart fallback import package name mismatch** — `packaging/npm/dart/bin/server.dart` imported `package:flutter_skill/...` but `dart/pubspec.yaml` declares the package as `flutter_skill_npm`. Updated the import to match.

## Test plan

- [ ] Delete `~/.flutter-skill` to clear any cached binary, restart the MCP server — it should fall back to Dart and start successfully
- [ ] Verify a partial/empty binary at `~/.flutter-skill/bin/` is skipped and re-downloaded rather than executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)