### PR TITLE
fix: fall back to Dart on
  native binary spawn errors; drop retired macOS x64 CI target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,10 +220,8 @@ jobs:
         run: |
           cd binaries
           SHA256_ARM64=$(sha256sum flutter-skill-macos-arm64/flutter-skill-macos-arm64 | cut -d' ' -f1)
-          SHA256_X64=$(sha256sum flutter-skill-macos-x64/flutter-skill-macos-x64 | cut -d' ' -f1)
           SHA256_LINUX=$(sha256sum flutter-skill-linux-x64/flutter-skill-linux-x64 | cut -d' ' -f1)
           echo "sha256_arm64=$SHA256_ARM64" >> $GITHUB_OUTPUT
-          echo "sha256_x64=$SHA256_X64" >> $GITHUB_OUTPUT
           echo "sha256_linux=$SHA256_LINUX" >> $GITHUB_OUTPUT
 
       - name: Checkout Homebrew tap
@@ -237,7 +235,6 @@ jobs:
         run: |
           VERSION=${{ needs.prepare.outputs.version }}
           SHA256_ARM64=${{ steps.sha256.outputs.sha256_arm64 }}
-          SHA256_X64=${{ steps.sha256.outputs.sha256_x64 }}
           SHA256_LINUX=${{ steps.sha256.outputs.sha256_linux }}
 
           # Write the new formula
@@ -252,10 +249,6 @@ jobs:
               on_arm do
                 url "https://github.com/ai-dashboad/flutter-skill/releases/download/vVERSION_PLACEHOLDER/flutter-skill-macos-arm64"
                 sha256 "SHA256_ARM64_PLACEHOLDER"
-              end
-              on_intel do
-                url "https://github.com/ai-dashboad/flutter-skill/releases/download/vVERSION_PLACEHOLDER/flutter-skill-macos-x64"
-                sha256 "SHA256_X64_PLACEHOLDER"
               end
             end
 
@@ -298,7 +291,6 @@ jobs:
           # Replace placeholders
           sed -i "s/VERSION_PLACEHOLDER/${VERSION}/g" homebrew-tap/Formula/flutter-skill.rb
           sed -i "s/SHA256_ARM64_PLACEHOLDER/${SHA256_ARM64}/g" homebrew-tap/Formula/flutter-skill.rb
-          sed -i "s/SHA256_X64_PLACEHOLDER/${SHA256_X64}/g" homebrew-tap/Formula/flutter-skill.rb
           sed -i "s/SHA256_LINUX_PLACEHOLDER/${SHA256_LINUX}/g" homebrew-tap/Formula/flutter-skill.rb
 
       - name: Commit and push
@@ -319,9 +311,6 @@ jobs:
           - os: macos-latest
             arch: arm64
             artifact: flutter-skill-macos-arm64
-          - os: macos-13
-            arch: x64
-            artifact: flutter-skill-macos-x64
           - os: ubuntu-latest
             arch: x64
             artifact: flutter-skill-linux-x64

--- a/packaging/homebrew/flutter-skill.rb
+++ b/packaging/homebrew/flutter-skill.rb
@@ -5,14 +5,14 @@ class FlutterSkill < Formula
   license "MIT"
 
   # Platform-specific native binaries
+  # Intel macOS (x64) has no native binary: GitHub retired the macos-13 hosted
+  # runner used to build it, and current x64 runner images require a paid
+  # large-runner tier. Intel Mac users should install via npm/pub.dev instead,
+  # which fall back to the Dart runtime automatically.
   on_macos do
     on_arm do
       url "https://github.com/ai-dashboad/flutter-skill/releases/download/v0.9.36/flutter-skill-macos-arm64"
       sha256 "PLACEHOLDER_ARM64_SHA256"
-    end
-    on_intel do
-      url "https://github.com/ai-dashboad/flutter-skill/releases/download/v0.9.36/flutter-skill-macos-x64"
-      sha256 "PLACEHOLDER_X64_SHA256"
     end
   end
 

--- a/packaging/npm/bin/cli.js
+++ b/packaging/npm/bin/cli.js
@@ -122,8 +122,25 @@ function runNativeBinary(binaryPath) {
     args.push('server');
   }
 
-  const server = spawn(binaryPath, args, {
-    stdio: 'inherit'
+  // spawn() reports launch failures (ENOEXEC, EACCES, ENOENT, wrong-arch, ...)
+  // inconsistently across platforms/Node versions: some surface synchronously
+  // as a thrown exception from spawn() itself, others only asynchronously via
+  // the 'error' event. Without handling both, the failure is uncaught and
+  // crashes the process instead of ever reaching the Dart fallback.
+  let server;
+  try {
+    server = spawn(binaryPath, args, {
+      stdio: 'inherit'
+    });
+  } catch (err) {
+    console.error(`[flutter-skill] Native binary failed to launch (${err.code || err.message}), falling back to Dart runtime`);
+    runWithDart();
+    return;
+  }
+
+  server.on('error', (err) => {
+    console.error(`[flutter-skill] Native binary failed to launch (${err.code || err.message}), falling back to Dart runtime`);
+    runWithDart();
   });
 
   server.on('close', (code) => {


### PR DESCRIPTION
## Summary
- `runNativeBinary()` had no handler for `spawn()` launch failures. On macOS/Node 22, `spawn()` throws `ENOEXEC` **synchronously** for a non-executable cached binary; other failure modes (`EACCES`, wrong-arch) surface only via the async `'error'` event. Neither path was covered, so a bad cached binary crashed the CLI instead of reaching the Dart fallback `main()` already implements for the "binary missing" case. Fixed by wrapping the `spawn()` call in `try/catch` and adding an `'error'` listener, both routing to `runWithDart()`.
- Root-caused the [v0.9.36 release run failure](https://github.com/ai-dashboad/flutter-skill/actions/runs/24440600087): `build-native-binaries (macos-13, x64)` can no longer schedule because GitHub retired the `macos-13` hosted runner, and current x64 macOS runner images require the paid large-runner tier. `create-release` requires every `build-native-binaries` matrix entry to succeed, so that one failure silently skipped `create-release` for the whole release — npm/pub.dev/vscode all published `v0.9.36`, but no GitHub Release or binaries were ever created, which is why the npm wrapper's download URLs 404. Dropped the `macos-13`/x64 matrix entry and its dependents (Homebrew SHA256 computation + `on_intel` block) rather than switching to a paid runner label, since that needs org-level runner/billing configuration I can't confirm is set up. npm/VSCode/IntelliJ already fall back to the Dart runtime when a native binary 404s, so Intel Mac users lose only the native-binary fast path; Homebrew on Intel now fails formula resolution with Homebrew's standard unsupported-platform error instead of trying to install a binary that no longer exists.

## Test plan
- [x] `node -c bin/cli.js` — syntax check passes
- [x] Simulated a 0-byte cached binary → confirmed existing size-check fallback still reaches Dart runtime cleanly
- [x] Simulated a non-empty but non-executable cached binary (reproduces the exact `ENOEXEC` synchronous-throw crash) → confirmed it now logs a warning and falls back to Dart instead of crashing
- [x] Simulated a valid executable in the cache path → confirmed the native-binary happy path is unaffected
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — release.yml parses as valid YAML after the matrix/Homebrew edits
- [ ] Full `release.yml` run end-to-end (requires a real `v*` tag push — not exercised here)

Generated with Claude Code
