### PR TITLE
fix(server): survive malformed JSON-RPC frames instead of exiting

### DIFF
--- a/lib/src/cli/server.dart
+++ b/lib/src/cli/server.dart
@@ -364,20 +364,55 @@ class FlutterMcpServer {
   }
 
   Future<void> run() async {
+    final done = Completer<void>();
+
+    // `allowMalformed: true` replaces invalid byte sequences with U+FFFD
+    // instead of throwing. A strict decoder raises FormatException on the
+    // *stream*, which bypasses the per-line try/catch below and kills the
+    // process — a single garbled byte from any client is enough to end the
+    // session. Malformed bytes now degrade into an ordinary parse error.
     stdin
-        .transform(utf8.decoder)
+        .transform(const Utf8Decoder(allowMalformed: true))
         .transform(const LineSplitter())
-        .listen((line) async {
-      if (line.trim().isEmpty) return;
-      try {
-        final request = jsonDecode(line);
-        if (request is Map<String, dynamic>) {
-          await _handleRequest(request);
+        .listen(
+      (line) async {
+        // A failure while handling one frame must never end the session, so
+        // every path here is guarded and answers with a JSON-RPC error.
+        try {
+          if (line.trim().isEmpty) return;
+          final dynamic request;
+          try {
+            request = jsonDecode(line);
+          } catch (e) {
+            _sendProtocolError(-32700, 'Parse error: $e');
+            return;
+          }
+          if (request is Map<String, dynamic>) {
+            await _handleRequest(request);
+          } else {
+            // Valid JSON, but not a JSON-RPC request object.
+            _sendProtocolError(
+                -32600, 'Invalid Request: expected a JSON object');
+          }
+        } catch (e) {
+          _sendProtocolError(-32603, 'Internal error: $e');
         }
-      } catch (e) {
-        _sendError(null, -32700, "Parse error: $e");
-      }
-    });
+      },
+      // Without an onError handler a stream-level error is unhandled and
+      // terminates the isolate. Keep reading instead.
+      onError: (Object e) {
+        _sendProtocolError(-32700, 'Parse error: $e');
+      },
+      onDone: () {
+        if (!done.isCompleted) done.complete();
+      },
+      cancelOnError: false,
+    );
+
+    // Keep `runServer` awaiting until stdin closes; otherwise it returns
+    // immediately and releases the single-instance lock while the server is
+    // still serving requests.
+    await done.future;
   }
 
   Future<void> _handleRequest(Map<String, dynamic> request) async {
@@ -1084,6 +1119,20 @@ class FlutterMcpServer {
   void _sendResult(dynamic id, dynamic result) {
     if (id == null) return;
     stdout.writeln(jsonEncode({"jsonrpc": "2.0", "id": id, "result": result}));
+  }
+
+  /// Reports an error that occurred before a request id could be read.
+  ///
+  /// [_sendError] drops null ids so that notifications stay unanswered, but
+  /// JSON-RPC 2.0 requires parse and invalid-request errors to be reported
+  /// with a null id. Without this the client sees silence and treats the
+  /// server as hung.
+  void _sendProtocolError(int code, String message) {
+    stdout.writeln(jsonEncode({
+      "jsonrpc": "2.0",
+      "id": null,
+      "error": {"code": code, "message": message},
+    }));
   }
 
   void _sendError(dynamic id, int code, String message) {

--- a/test/server_malformed_frame_test.dart
+++ b/test/server_malformed_frame_test.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:async/async.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression tests for the JSON-RPC read loop.
+///
+/// A malformed frame from any client used to end the session: invalid UTF-8
+/// raised a stream-level FormatException that no handler caught, and a
+/// truncated JSON object produced no reply at all because the parse error was
+/// dropped for having a null id. Both are denial-of-service primitives against
+/// a stdio MCP server, so they are pinned here.
+void main() {
+  group('MCP server JSON-RPC framing', () {
+    late Process server;
+    late StreamQueue<String> responses;
+
+    /// Longest a single well-formed request may take to come back. Generous so
+    /// the suite stays reliable on a cold CI machine.
+    const responseTimeout = Duration(seconds: 30);
+
+    /// Under `flutter test` the running executable is `flutter_tester`, which
+    /// cannot run a plain Dart entrypoint, so resolve the real Dart SDK.
+    String dartExecutable() {
+      final flutterRoot = Platform.environment['FLUTTER_ROOT'];
+      if (flutterRoot != null && flutterRoot.isNotEmpty) {
+        final sdkDart = File(
+            '$flutterRoot/bin/cache/dart-sdk/bin/dart${Platform.isWindows ? '.exe' : ''}');
+        if (sdkDart.existsSync()) return sdkDart.path;
+      }
+      return 'dart';
+    }
+
+    Future<void> send(List<int> bytes) async {
+      server.stdin.add(bytes);
+      await server.stdin.flush();
+    }
+
+    Future<void> sendJson(Object frame) => send(utf8.encode('${jsonEncode(frame)}\n'));
+
+    Future<Map<String, dynamic>> nextResponse() async {
+      final line = await responses.next.timeout(
+        responseTimeout,
+        onTimeout: () => throw StateError(
+            'Server sent no response — it most likely died on the previous frame'),
+      );
+      return jsonDecode(line) as Map<String, dynamic>;
+    }
+
+    setUp(() async {
+      // The server refuses to start while another instance holds the lock.
+      final home = Platform.environment['HOME'] ??
+          Platform.environment['USERPROFILE'] ??
+          '/tmp';
+      final lock = File('$home/.flutter_skill.lock');
+      if (await lock.exists()) await lock.delete();
+
+      server = await Process.start(
+        dartExecutable(),
+        ['run', 'bin/server.dart', 'server'],
+      );
+      server.stderr.drain<void>();
+      responses = StreamQueue(server.stdout
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          // The child inherits the test runner's VM service flags and prints an
+          // "observatory listening" banner on stdout. Keep only JSON-RPC frames.
+          .where((line) => line.startsWith('{')));
+
+      // Handshake first so a failure later is unambiguously caused by the
+      // hostile frame under test and not by a server that never came up.
+      await sendJson({
+        'jsonrpc': '2.0',
+        'id': 1,
+        'method': 'initialize',
+        'params': <String, dynamic>{},
+      });
+      final hello = await nextResponse();
+      expect(hello['id'], 1);
+      expect(hello['result'], isNotNull);
+    });
+
+    tearDown(() async {
+      await responses.cancel(immediate: true);
+      server.kill();
+      await server.exitCode;
+    });
+
+    /// Drives one hostile frame and asserts the server answers it and is still
+    /// able to serve a normal request afterwards.
+    Future<void> expectSurvives(
+      List<int> hostileFrame, {
+      required int expectedCode,
+    }) async {
+      await send(hostileFrame);
+
+      final error = await nextResponse();
+      expect(error['id'], isNull,
+          reason: 'JSON-RPC 2.0 requires a null id when the id is unreadable');
+      expect(error['error']['code'], expectedCode);
+
+      await sendJson({
+        'jsonrpc': '2.0',
+        'id': 99,
+        'method': 'tools/list',
+        'params': <String, dynamic>{},
+      });
+      final after = await nextResponse();
+      expect(after['id'], 99,
+          reason: 'Server must still serve requests after a malformed frame');
+    }
+
+    test('should answer a parse error when a frame is truncated JSON', () async {
+      await expectSurvives(utf8.encode('{"jsonrpc":"2.0","id":2,\n'),
+          expectedCode: -32700);
+    });
+
+    test('should answer a parse error when a frame is not JSON at all', () async {
+      await expectSurvives(utf8.encode('not json at all }{\n'),
+          expectedCode: -32700);
+    });
+
+    test('should survive invalid UTF-8 bytes instead of exiting', () async {
+      // A strict utf8.decoder throws on the stream rather than in the per-line
+      // handler, which previously terminated the process.
+      await expectSurvives([0xff, 0xfe, 0xfd, 0x0a], expectedCode: -32700);
+    });
+
+    test('should reject valid JSON that is not a request object', () async {
+      await expectSurvives(utf8.encode('[1,2,3]\n'), expectedCode: -32600);
+    });
+
+    test('should stay silent for a notification carrying no id', () async {
+      await sendJson({'jsonrpc': '2.0', 'method': 'notifications/initialized'});
+
+      // Nothing should come back for the notification, so the next line read
+      // must belong to the request sent after it.
+      await sendJson({
+        'jsonrpc': '2.0',
+        'id': 50,
+        'method': 'tools/list',
+        'params': <String, dynamic>{},
+      });
+      final next = await nextResponse();
+      expect(next['id'], 50,
+          reason: 'A notification must not produce a response');
+    });
+  });
+}


### PR DESCRIPTION
Fixes #54.

## Summary

A single malformed frame from any client ended the MCP session. Reproduced against `main` with a stdio probe; two independent defects were responsible.

**1. Invalid UTF-8 killed the process.** `stdin.transform(utf8.decoder)` raises `FormatException` on the *stream*, not inside the per-line callback, and `listen()` had no `onError`. The exception was unhandled and terminated the isolate:

```
[ERR] Unhandled exception:
[ERR] FormatException: Invalid UTF-8 byte (at offset 0)
### exited=255
```

That is the `unresponsive after malformed input (eof)` verdict in the report.

**2. Parse errors were silently dropped.** Truncated JSON *was* caught, but the reply went through `_sendError(null, -32700, ...)`, and `_sendError` opens with `if (id == null) return;`. The guard is correct for notifications and wrong for parse errors — JSON-RPC 2.0 requires them to be answered with a null id. The client saw silence and concluded the server was hung.

## Changes

- Decode with `Utf8Decoder(allowMalformed: true)` so bad bytes become U+FFFD and degrade into an ordinary parse error instead of a stream failure.
- Add `onError` and `cancelOnError: false` to the stdin subscription so no stream-level error can end the session.
- Add `_sendProtocolError(code, message)` for the null-id replies the spec requires, leaving `_sendError`'s notification behaviour untouched.
- Answer `-32600 Invalid Request` for frames that are valid JSON but not request objects (previously ignored with no reply).
- `run()` now awaits stdin closing. It used to return as soon as the listener was attached, so `runServer` released the single-instance lock while the server was still live.

## Test plan

- [x] New `test/server_malformed_frame_test.dart` drives a real server subprocess through truncated JSON, non-JSON text, invalid UTF-8 bytes, and a JSON array, asserting each is answered *and* that a following `tools/list` still succeeds. A fifth test pins that notifications stay unanswered.
- [x] Verified the tests are not vacuous: **4 of 5 fail on `main`**, 5/5 pass with the fix. (The notification test passes on both, as intended.)
- [x] `flutter analyze lib/src/cli/server.dart test/server_malformed_frame_test.dart` — no issues.
- [x] Manual probe: 6 hostile frames in a row, server answers each and continues serving.

```
--- MALFORMED json (truncated)
[OUT] {"jsonrpc":"2.0","id":null,"error":{"code":-32700,...}}
--- INVALID UTF-8 bytes
[OUT] {"jsonrpc":"2.0","id":null,"error":{"code":-32700,...}}
--- JSON array (not an object)
[OUT] {"jsonrpc":"2.0","id":null,"error":{"code":-32600,...}}
--- notification (no id, must be silent)
--- valid tools/list
[OUT] {"jsonrpc":"2.0","id":9,"result":{"tools":[...]}}
### exited=None  alive=True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)