### PR TITLE
fix(npm): make the Dart fallback usable on Windows and diagnose failures

### DIFF
--- a/packaging/npm/bin/cli.js
+++ b/packaging/npm/bin/cli.js
@@ -151,35 +151,61 @@ function runNativeBinary(binaryPath) {
   process.on('SIGTERM', () => server.kill('SIGTERM'));
 }
 
+const isWindows = process.platform === 'win32';
+
+// The Flutter and Dart entrypoints on Windows are `.bat` scripts, which
+// CreateProcess cannot execute directly — spawn() fails with UNKNOWN or ENOENT
+// unless it goes through a shell. A shell does no argument quoting for us, so
+// anything containing whitespace has to be quoted by hand.
+function quoteArg(value) {
+  return isWindows && /[\s&|<>^()]/.test(value) ? `"${value}"` : value;
+}
+
 // Run using Dart
 function runWithDart() {
   const dartDir = path.join(__dirname, '..', 'dart');
   const serverScript = path.join(dartDir, 'bin', 'server.dart');
 
-  // Check if Dart is installed
-  try {
-    execSync('dart --version', { stdio: 'ignore' });
-  } catch (e) {
-    console.error('Error: Dart SDK not found. Please install Flutter/Dart first.');
+  if (!fs.existsSync(serverScript)) {
+    console.error('Error: Server script not found at:', serverScript);
+    console.error('The npm package looks incomplete — try reinstalling flutter-skill.');
+    process.exit(1);
+  }
+
+  // The vendored package depends on package:flutter, so `dart pub get` can
+  // never resolve it ("Because flutter_skill requires the Flutter SDK, version
+  // solving failed"). Checking only for Dart let that failure through and the
+  // run then died with a confusing "Couldn't resolve the package
+  // 'flutter_skill'" instead of naming the real prerequisite.
+  if (!checkFlutter()) {
+    console.error('Error: Flutter SDK not found.');
+    console.error('flutter-skill runs on the Flutter SDK — the Dart SDK alone cannot');
+    console.error('resolve its dependencies. Install Flutter and make sure it is on PATH:');
     console.error('  https://docs.flutter.dev/get-started/install');
     process.exit(1);
   }
 
-  // Check if server script exists
-  if (!fs.existsSync(serverScript)) {
-    console.error('Error: Server script not found at:', serverScript);
+  try {
+    execSync('dart --version', { stdio: 'ignore' });
+  } catch (e) {
+    console.error('Error: `dart` was not found on PATH, but `flutter` was.');
+    console.error('Add the Flutter SDK\'s bin directory to PATH so `dart` resolves too.');
     process.exit(1);
   }
 
-  // Get dependencies silently
+  // A failure here used to be swallowed, leaving the run to fail later with an
+  // unrelated-looking import error. Report it and stop.
   try {
-    const pubCmd = checkFlutter() ? 'flutter' : 'dart';
-    execSync(`${pubCmd} pub get`, {
+    execSync('flutter pub get', {
       cwd: dartDir,
       stdio: ['ignore', 'pipe', 'pipe']
     });
   } catch (e) {
-    // Ignore pub get errors
+    console.error('[flutter-skill] `flutter pub get` failed in', dartDir);
+    const details = ((e.stderr || '') + (e.stdout || '')).toString().trim();
+    if (details) console.error(details);
+    console.error('[flutter-skill] Cannot start without resolved dependencies.');
+    process.exit(1);
   }
 
   // Start with Dart
@@ -188,10 +214,27 @@ function runWithDart() {
     args.push('server');
   }
 
-  const dartArgs = ['run', serverScript, ...args];
-  const server = spawn('dart', dartArgs, {
-    cwd: dartDir,
-    stdio: 'inherit'
+  const dartArgs = ['run', serverScript, ...args].map(quoteArg);
+
+  // Same launch-failure handling as the native path: spawn() reports failures
+  // synchronously on some platforms and only via the 'error' event on others.
+  // There is no further fallback beyond Dart, so both paths exit with a
+  // diagnostic rather than crashing on an uncaught exception.
+  let server;
+  try {
+    server = spawn('dart', dartArgs, {
+      cwd: dartDir,
+      stdio: 'inherit',
+      shell: isWindows
+    });
+  } catch (err) {
+    console.error(`[flutter-skill] Failed to start the Dart runtime (${err.code || err.message})`);
+    process.exit(1);
+  }
+
+  server.on('error', (err) => {
+    console.error(`[flutter-skill] Failed to start the Dart runtime (${err.code || err.message})`);
+    process.exit(1);
   });
 
   server.on('close', (code) => {

--- a/packaging/npm/scripts/postinstall.js
+++ b/packaging/npm/scripts/postinstall.js
@@ -39,6 +39,9 @@ function downloadBinary(url, destPath) {
         }
 
         if (response.statusCode !== 200) {
+          // createWriteStream has already created an empty file. Leaving it
+          // behind makes every later install believe the binary is present.
+          file.close(() => fs.unlink(destPath, () => {}));
           reject(new Error(`HTTP ${response.statusCode}`));
           return;
         }
@@ -68,7 +71,10 @@ function downloadBinary(url, destPath) {
           console.log('\n[flutter-skill] Native binary installed successfully!');
           resolve(destPath);
         });
-      }).on('error', reject);
+      }).on('error', (err) => {
+        file.close(() => fs.unlink(destPath, () => {}));
+        reject(err);
+      });
     };
 
     request(url);
@@ -84,7 +90,9 @@ async function main() {
 
   const localPath = path.join(binDir, `${binaryName}-v${VERSION}`);
 
-  if (fs.existsSync(localPath)) {
+  // A zero-byte file is the residue of an interrupted or 404'd download, not an
+  // installed binary. Treat it as absent so the download is retried.
+  if (fs.existsSync(localPath) && fs.statSync(localPath).size > 0) {
     // Re-apply execute permission in case a previous install left the binary
     // without +x (e.g. chmod failed silently inside a restricted npm sandbox).
     try { fs.chmodSync(localPath, 0o755); } catch (_) {}


### PR DESCRIPTION
Addresses #45, #49 and #50.

## Summary

#55 fixed the crash when the *native binary* fails to spawn, so the CLI now reaches the Dart fallback. But that fallback was itself broken, so users landed on a second failure with a misleading message.

### 1. The Dart fallback could not launch on Windows

`spawn('dart', dartArgs)` cannot start the Windows SDK entrypoints — they are `.bat` scripts, and `CreateProcess` refuses to execute them directly. It fails with exactly the `spawn UNKNOWN` reported in #45, and that spawn had **no error handling at all**, so the process crashed rather than reporting anything.

Now spawns through a shell on Windows (quoting arguments by hand, since a shell does none) and guards both the synchronous throw and the async `'error'` event, matching what #55 did for the native path.

### 2. The prerequisite check named the wrong SDK

It only looked for Dart. But the vendored package depends on `package:flutter`, so `dart pub get` can *never* resolve it:

```
Because flutter_skill requires the Flutter SDK, version solving failed.
Flutter users should use `flutter pub` instead of `dart pub`.
```

The run then died with `Couldn't resolve the package 'flutter_skill'` — the exact error in #49, which points at the package rather than at the missing Flutter SDK. Now requires Flutter and says so.

### 3. `flutter pub get` failures were swallowed

`catch (e) { // Ignore pub get errors }` discarded the reason, and the failure resurfaced later as an unrelated import error. Now the output is printed and the process stops.

### 4. A failed download poisoned every later install

`createWriteStream` opens the destination *before* the status code is known, so a 404 (which is what #57 causes) or a connection error left a **zero-byte file** behind. `postinstall`'s check was `fs.existsSync(localPath)`, so every subsequent install reported "Native binary already installed" and never retried. The partial file is now removed on failure, and a zero-byte file counts as absent.

## Test plan

Verified against a stubbed `PATH`:

- [x] **No Flutter, no Dart** → `Error: Flutter SDK not found` with the install link (was: crash or a package-resolution error)
- [x] **Dart present, Flutter absent** — the #49 setup → names the Flutter SDK as the prerequisite instead of `Couldn't resolve the package 'flutter_skill'`
- [x] **`flutter pub get` fails** (broken pubspec) → prints `` `flutter pub get` failed in <dir> `` followed by pub's actual output, then exits
- [x] **Full chain**: planted a corrupt cached native binary → `Native binary failed to launch (ENOEXEC), falling back to Dart runtime` → Dart server starts and answers `initialize`
- [x] `node -c` on both `bin/cli.js` and `scripts/postinstall.js`

The Windows shell path is reasoned from `CreateProcess` semantics and is not exercised on this machine.

## Note

The full-chain test also shows why #61 matters — the fallback answers with:

```json
"serverInfo":{"name":"flutter-skill","version":"0.2.0"}
```

It then prints its own "update available" banner against itself. The vendored Dart tree is that stale; #61 regenerates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)